### PR TITLE
Added MAZE_REPEATER_API_KEY to docker-compose.yml environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       BUILDKITE_RETRY_COUNT:
       BUILDKITE_STEP_KEY:
       MAZE_BUGSNAG_API_KEY:
+      MAZE_REPEATER_API_KEY:
     ports:
       - "9000-9499:9339"
     volumes:


### PR DESCRIPTION
## Goal

We want spans that are sent during E2E testing to appear on our Bugsnag Dashboard.

## Changeset

An environment variable was added so that mazerunner passes the spans to the correct Bugsnag project