### PR TITLE
PLAT-11861 bump minimum flutter version to 3.10

### DIFF
--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: ">=3.3.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   crypto: ^3.0.3


### PR DESCRIPTION
## Goal

bump minimum flutter version to 3.10


## Testing

covered by e2e and unit tests