### PR TITLE
View load instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* View load instrumentation
+  [65](https://github.com/bugsnag/bugsnag-flutter-performance/pull/65)
+
 ## 1.0.0 (2024-04-11)
 
 Initial release

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -154,3 +154,89 @@ Feature: Automatic instrumentation spans
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
+
+  Scenario: AutoInstrumentViewLoadBasicScenario
+    Given I run "AutoInstrumentViewLoadBasicScenario"
+    And I wait for 3 spans
+    And I wait for 3 seconds
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:3"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/building"
+    * a span string attribute "bugsnag.phase" equals "building"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/appearing"
+    * a span string attribute "bugsnag.phase" equals "appearing"
+    * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/loading" exists
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/building"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/appearing"
+
+  Scenario: AutoInstrumentViewLoadBasicDeferScenario
+    Given I run "AutoInstrumentViewLoadBasicDeferScenario"
+    And I wait for 2 spans
+    And I wait for 3 seconds
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/building"
+    * a span string attribute "bugsnag.phase" equals "building"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/appearing"
+    * a span string attribute "bugsnag.phase" equals "appearing"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
+    * no span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget" exists
+    * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading" exists
+    And I invoke "step2"
+    And I wait for 4 spans
+    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/building"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/appearing"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading"
+
+  Scenario: AutoInstrumentViewLoadNestedScenario
+    Given I run "AutoInstrumentViewLoadNestedScenario"
+    And I wait for 4 spans
+    And I wait for 3 seconds
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/building"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/building"
+    * a span string attribute "bugsnag.phase" equals "building"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/appearing"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/appearing"
+    * a span string attribute "bugsnag.phase" equals "appearing"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
+    * no span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget" exists
+    * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/loading" exists
+    * no span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" exists
+    * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading" exists
+    And I invoke "step2"
+    And I wait for 8 spans
+    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget"
+    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/loading"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/building"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/appearing"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/loading"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/building"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/appearing"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading"

--- a/features/fixture_resources/lib/scenarios/auto_instrument_view_load_basic_defer_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_view_load_basic_defer_scenario.dart
@@ -1,0 +1,76 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+import 'package:flutter/material.dart';
+
+import 'scenario.dart';
+
+class AutoInstrumentViewLoadBasicDeferScenario extends Scenario {
+  final _key =
+      GlobalKey<_AutoInstrumentViewLoadBasicDeferScenarioScreenState>();
+
+  @override
+  Future<void> run() async {
+    setInstrumentsViewLoad(true);
+    await startBugsnag();
+    setMaxBatchSize(1);
+  }
+
+  @override
+  Widget? createWidget() {
+    return MeasuredWidget(
+      name: 'AutoInstrumentViewLoadBasicDeferScenarioWidget',
+      builder: (_) => AutoInstrumentViewLoadBasicDeferScenarioScreen(
+        key: _key,
+        runCommandCallback: () => runCommandCallback!(),
+      ),
+    );
+  }
+
+  void step2() {
+    _key.currentState!.setStage(2);
+  }
+
+  @override
+  void invokeMethod(String name) {
+    switch (name) {
+      case 'step2':
+        step2();
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+class AutoInstrumentViewLoadBasicDeferScenarioScreen extends StatefulWidget {
+  const AutoInstrumentViewLoadBasicDeferScenarioScreen({
+    super.key,
+    required this.runCommandCallback,
+  });
+  final void Function() runCommandCallback;
+
+  @override
+  State<AutoInstrumentViewLoadBasicDeferScenarioScreen> createState() =>
+      _AutoInstrumentViewLoadBasicDeferScenarioScreenState();
+}
+
+class _AutoInstrumentViewLoadBasicDeferScenarioScreenState
+    extends State<AutoInstrumentViewLoadBasicDeferScenarioScreen> {
+  var _stage = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_stage < 2) {
+      return GestureDetector(
+        child: const BugsnagLoadingIndicator(child: Text('Loading...')),
+        onTap: () => widget.runCommandCallback(),
+      );
+    }
+    return const Text('AutoInstrumentViewLoadBasicDeferScenarioScreen');
+  }
+
+  void setStage(int stage) {
+    setState(() {
+      _stage = stage;
+    });
+  }
+}

--- a/features/fixture_resources/lib/scenarios/auto_instrument_view_load_basic_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_view_load_basic_scenario.dart
@@ -1,0 +1,22 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import 'scenario.dart';
+
+class AutoInstrumentViewLoadBasicScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    setInstrumentsViewLoad(true);
+    await startBugsnag();
+    setMaxBatchSize(3);
+  }
+
+  @override
+  Widget? createWidget() {
+    return MeasuredWidget(
+      name: 'AutoInstrumentViewLoadBasicScenarioWidget',
+      builder: (context) => const Text('AutoInstrumentViewLoadBasicScenario'),
+    );
+  }
+}

--- a/features/fixture_resources/lib/scenarios/auto_instrument_view_load_nested_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_view_load_nested_scenario.dart
@@ -1,0 +1,78 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+import 'package:flutter/material.dart';
+
+import 'scenario.dart';
+
+class AutoInstrumentViewLoadNestedScenario extends Scenario {
+  final _key = GlobalKey<_AutoInstrumentViewLoadNestedScenarioScreenState>();
+
+  @override
+  Future<void> run() async {
+    setInstrumentsViewLoad(true);
+    await startBugsnag();
+    setMaxBatchSize(1);
+  }
+
+  @override
+  Widget? createWidget() {
+    return MeasuredWidget(
+      name: 'AutoInstrumentViewLoadNestedScenarioWidget',
+      builder: (_) => MeasuredWidget(
+        name: 'AutoInstrumentViewLoadNestedScenarioChildWidget',
+        builder: (_) => AutoInstrumentViewLoadNestedScenarioScreen(
+          key: _key,
+          runCommandCallback: () => runCommandCallback!(),
+        ),
+      ),
+    );
+  }
+
+  void step2() {
+    _key.currentState!.setStage(2);
+  }
+
+  @override
+  void invokeMethod(String name) {
+    switch (name) {
+      case 'step2':
+        step2();
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+class AutoInstrumentViewLoadNestedScenarioScreen extends StatefulWidget {
+  const AutoInstrumentViewLoadNestedScenarioScreen({
+    super.key,
+    required this.runCommandCallback,
+  });
+  final void Function() runCommandCallback;
+
+  @override
+  State<AutoInstrumentViewLoadNestedScenarioScreen> createState() =>
+      _AutoInstrumentViewLoadNestedScenarioScreenState();
+}
+
+class _AutoInstrumentViewLoadNestedScenarioScreenState
+    extends State<AutoInstrumentViewLoadNestedScenarioScreen> {
+  var _stage = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_stage < 2) {
+      return GestureDetector(
+        child: const BugsnagLoadingIndicator(child: Text('Loading...')),
+        onTap: () => widget.runCommandCallback(),
+      );
+    }
+    return const Text('AutoInstrumentViewLoadNestedScenarioScreen');
+  }
+
+  void setStage(int stage) {
+    setState(() {
+      _stage = stage;
+    });
+  }
+}

--- a/features/fixture_resources/lib/scenarios/scenario.dart
+++ b/features/fixture_resources/lib/scenarios/scenario.dart
@@ -35,6 +35,10 @@ abstract class Scenario {
     bugsnag_performance.setExtraConfig("instrumentNavigation", value);
   }
 
+  void setInstrumentsViewLoad(bool value) {
+    bugsnag_performance.setExtraConfig("instrumentViewLoad", value);
+  }
+
   Future<void> startBugsnag({
     String? releaseStage,
     List<String>? enabledReleaseStages,

--- a/features/fixture_resources/lib/scenarios/scenarios.dart
+++ b/features/fixture_resources/lib/scenarios/scenarios.dart
@@ -3,6 +3,9 @@ import 'package:mazerunner/scenarios/auto_instrument_navigation_basic_scenario.d
 import 'package:mazerunner/scenarios/auto_instrument_navigation_complex_defer_scenario.dart';
 import 'package:mazerunner/scenarios/auto_instrument_navigation_nested_navigation_scenario.dart';
 import 'package:mazerunner/scenarios/auto_instrument_navigation_push_and_pop_scenario.dart';
+import 'package:mazerunner/scenarios/auto_instrument_view_load_basic_defer_scenario.dart';
+import 'package:mazerunner/scenarios/auto_instrument_view_load_basic_scenario.dart';
+import 'package:mazerunner/scenarios/auto_instrument_view_load_nested_scenario.dart';
 
 import 'auto_instrument_app_starts_scenario.dart';
 import 'dio_callback_cancel_span.dart';
@@ -95,4 +98,10 @@ final List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('SpanWithNoParentScenario', () => SpanWithNoParentScenario()),
   ScenarioInfo(
       'ManualNavigationSpanScenario', () => ManualNavigationSpanScenario()),
+  ScenarioInfo('AutoInstrumentViewLoadBasicScenario',
+      () => AutoInstrumentViewLoadBasicScenario()),
+  ScenarioInfo('AutoInstrumentViewLoadBasicDeferScenario',
+      () => AutoInstrumentViewLoadBasicDeferScenario()),
+  ScenarioInfo('AutoInstrumentViewLoadNestedScenario',
+      () => AutoInstrumentViewLoadNestedScenario()),
 ];

--- a/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
+++ b/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
@@ -18,6 +18,7 @@ export 'src/widgets/bugsnag_navigation_container.dart'
     show BugsnagNavigationContainer;
 export 'src/instrumentation/navigation/bugsnag_performance_navigator_observer.dart'
     show BugsnagPerformanceNavigatorObserver;
+export 'src/widgets/measured_widget.dart' show MeasuredWidget;
 
 class InvalidBugsnagApiKeyException implements Exception {
   String message;

--- a/packages/bugsnag_flutter_performance/lib/src/configuration.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/configuration.dart
@@ -13,6 +13,7 @@ class BugsnagPerformanceConfiguration {
   int probabilityValueExpireTime = 24 * 3600 * 1000;
   bool instrumentAppStart = true;
   bool instrumentNavigation = true;
+  bool instrumentViewLoad = true;
   String? releaseStage;
   List<String>? enabledReleaseStages;
   String? appVersion;
@@ -39,6 +40,9 @@ class BugsnagPerformanceConfiguration {
         break;
       case 'instrumentNavigation':
         instrumentNavigation = value;
+        break;
+      case 'instrumentViewLoad':
+        instrumentViewLoad = value;
         break;
       case 'maxBatchAge':
         maxBatchAge = value;

--- a/packages/bugsnag_flutter_performance/lib/src/instrumentation/navigation/navigation_instrumentation.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/instrumentation/navigation/navigation_instrumentation.dart
@@ -1,5 +1,5 @@
 import 'package:bugsnag_flutter_performance/src/client.dart';
-import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/navigation_instrumentation_node.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_node.dart';
 import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_state.dart';
 import 'package:bugsnag_flutter_performance/src/span.dart';
 import 'package:bugsnag_flutter_performance/src/util/clock.dart';
@@ -150,14 +150,14 @@ class NavigationInstrumentationImpl implements NavigationInstrumentation {
     required String triggeredBy,
     String? previousRoute,
   }) {
-    if (!_enabled || state.viewLoadSpan != null) {
+    if (!_enabled || state.navigationSpan != null) {
       return;
     }
-    state.viewLoadSpan = client.startNavigationSpan(
+    state.navigationSpan = client.startNavigationSpan(
       routeName: state.name,
       navigatorName: state.navigatorName,
       previousRoute: previousRoute,
-      parentContext: state.nearestViewLoadSpan(),
+      parentContext: state.nearestNavigationSpan(),
       startTime: state.startTime,
       triggeredBy: triggeredBy,
     );
@@ -170,7 +170,7 @@ class NavigationInstrumentationImpl implements NavigationInstrumentation {
     if (!_enabled) {
       return;
     }
-    final span = state.viewLoadSpan;
+    final span = state.navigationSpan;
     if (span is BugsnagPerformanceSpanImpl) {
       span.attributes.setAttribute(
         'bugsnag.navigation.ended_by',

--- a/packages/bugsnag_flutter_performance/lib/src/instrumentation/navigation/widget_instrumentation_node.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/instrumentation/navigation/widget_instrumentation_node.dart
@@ -82,7 +82,7 @@ class WidgetInstrumentationNode {
 
   static WidgetInstrumentationNode of(BuildContext context) {
     final widget = context.dependOnInheritedWidgetOfExactType<
-        NavigationInstrumentationNodeProvider>();
+        WidgetInstrumentationNodeProvider>();
     return widget != null ? widget.node : appRootInstrumentationNode;
   }
 }

--- a/packages/bugsnag_flutter_performance/lib/src/instrumentation/navigation/widget_instrumentation_state.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/instrumentation/navigation/widget_instrumentation_state.dart
@@ -13,12 +13,12 @@ class WidgetInstrumentationState {
   final String? navigatorName;
 
   final DateTime startTime;
-  BugsnagPerformanceSpan? viewLoadSpan;
+  BugsnagPerformanceSpan? navigationSpan;
 
-  BugsnagPerformanceSpan? nearestViewLoadSpan() {
-    if (viewLoadSpan != null && viewLoadSpan!.isOpen()) {
-      return viewLoadSpan;
+  BugsnagPerformanceSpan? nearestNavigationSpan() {
+    if (navigationSpan != null && navigationSpan!.isOpen()) {
+      return navigationSpan;
     }
-    return parent?.nearestViewLoadSpan();
+    return parent?.nearestNavigationSpan();
   }
 }

--- a/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/measured_widget_callbacks.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/measured_widget_callbacks.dart
@@ -1,0 +1,50 @@
+import 'package:bugsnag_flutter_performance/src/instrumentation/view_load/view_load_instrumentation_state.dart';
+import 'package:flutter/widgets.dart';
+
+typedef MeasuredWidgetCallback = Function(
+  ViewLoadInstrumentationState state,
+  BuildContext context,
+);
+
+class MeasuredWidgetCallbacks {
+  MeasuredWidgetCallback? _willBuildCallback;
+  MeasuredWidgetCallback? _didBuildCallback;
+
+  void willBuildWidget({
+    required ViewLoadInstrumentationState state,
+    required BuildContext context,
+  }) {
+    if (_willBuildCallback != null) {
+      _willBuildCallback!(
+        state,
+        context,
+      );
+    }
+  }
+
+  void didBuildWidget({
+    required ViewLoadInstrumentationState state,
+    required BuildContext context,
+  }) {
+    if (_didBuildCallback != null) {
+      _didBuildCallback!(
+        state,
+        context,
+      );
+    }
+  }
+
+  static setup({
+    MeasuredWidgetCallback? willBuildCallback,
+    MeasuredWidgetCallback? didBuildCallback,
+  }) {
+    if (willBuildCallback != null) {
+      measuredWidgetCallbacks._willBuildCallback = willBuildCallback;
+    }
+    if (didBuildCallback != null) {
+      measuredWidgetCallbacks._didBuildCallback = didBuildCallback;
+    }
+  }
+}
+
+final measuredWidgetCallbacks = MeasuredWidgetCallbacks();

--- a/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/view_load_instrumentation.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/view_load_instrumentation.dart
@@ -1,0 +1,92 @@
+import 'package:bugsnag_flutter_performance/src/client.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_node.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/view_load/view_load_instrumentation_state.dart';
+import 'package:bugsnag_flutter_performance/src/util/clock.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+abstract class ViewLoadInstrumentation {
+  void setEnabled(bool enabled);
+  void willBuildView(
+    ViewLoadInstrumentationState state,
+    BuildContext context,
+  );
+  void didBuildView(
+    ViewLoadInstrumentationState state,
+    BuildContext context,
+  );
+}
+
+class ViewLoadInstrumentationImpl implements ViewLoadInstrumentation {
+  final BugsnagPerformanceClient client;
+  final BugsnagClock clock;
+
+  var _enabled = true;
+
+  ViewLoadInstrumentationImpl({
+    required this.client,
+    required this.clock,
+  });
+
+  @override
+  void setEnabled(bool enabled) {
+    _enabled = enabled;
+  }
+
+  @override
+  void willBuildView(
+    ViewLoadInstrumentationState state,
+    BuildContext context,
+  ) {
+    if (!_enabled || state.viewLoadSpan != null) {
+      return;
+    }
+    final viewLoadSpan = client.startViewLoadSpan(
+      viewName: state.name,
+    );
+    state.viewLoadSpan = viewLoadSpan;
+    state.buildingSpan = client.startViewLoadPhaseSpan(
+      viewName: state.name,
+      phase: 'building',
+      parentContext: viewLoadSpan,
+    );
+  }
+
+  @override
+  void didBuildView(
+    ViewLoadInstrumentationState state,
+    BuildContext context,
+  ) {
+    final viewLoadSpan = state.viewLoadSpan;
+    if (!_enabled ||
+        viewLoadSpan == null ||
+        state.buildingSpan == null ||
+        !state.buildingSpan!.isOpen() ||
+        state.appearingSpan != null) {
+      return;
+    }
+    state.buildingSpan?.end();
+    state.appearingSpan = client.startViewLoadPhaseSpan(
+      viewName: state.name,
+      phase: 'appearing',
+      parentContext: viewLoadSpan,
+    );
+    final node = WidgetInstrumentationNode.of(context);
+    SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
+      state.appearingSpan?.end();
+      if (node.isLoading()) {
+        state.loadingSpan = client.startViewLoadPhaseSpan(
+          viewName: state.name,
+          phase: 'loading',
+          parentContext: viewLoadSpan,
+        );
+        node.addDidFinishLoadingCallback(() {
+          state.loadingSpan?.end();
+          viewLoadSpan.end();
+        });
+      } else {
+        viewLoadSpan.end();
+      }
+    });
+  }
+}

--- a/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/view_load_instrumentation_state.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/view_load_instrumentation_state.dart
@@ -1,0 +1,16 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+
+class ViewLoadInstrumentationState {
+  ViewLoadInstrumentationState({
+    required this.name,
+    required this.startTime,
+  });
+
+  final String name;
+
+  final DateTime startTime;
+  BugsnagPerformanceSpan? viewLoadSpan;
+  BugsnagPerformanceSpan? buildingSpan;
+  BugsnagPerformanceSpan? appearingSpan;
+  BugsnagPerformanceSpan? loadingSpan;
+}

--- a/packages/bugsnag_flutter_performance/lib/src/widgets/bugsnag_loading_indicator.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/widgets/bugsnag_loading_indicator.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/navigation_instrumentation_node.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_node.dart';
 import 'package:flutter/widgets.dart';
 
 class BugsnagLoadingIndicator extends StatefulWidget {

--- a/packages/bugsnag_flutter_performance/lib/src/widgets/bugsnag_navigation_container.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/widgets/bugsnag_navigation_container.dart
@@ -1,4 +1,4 @@
-import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/navigation_instrumentation_node.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_node.dart';
 import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_state.dart';
 import 'package:bugsnag_flutter_performance/src/util/clock.dart';
 import 'package:bugsnag_flutter_performance/src/widgets/widget_instrumentation_node_provider.dart';
@@ -34,7 +34,7 @@ class _BugsnagNavigationContainerState
     );
     _currentNode = newNode;
     parentNode.addChild(newNode);
-    return NavigationInstrumentationNodeProvider(
+    return WidgetInstrumentationNodeProvider(
       node: newNode,
       child: widget.child,
     );

--- a/packages/bugsnag_flutter_performance/lib/src/widgets/measured_widget.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/widgets/measured_widget.dart
@@ -4,6 +4,7 @@ import 'package:bugsnag_flutter_performance/src/instrumentation/view_load/measur
 import 'package:bugsnag_flutter_performance/src/instrumentation/view_load/view_load_instrumentation_state.dart';
 import 'package:bugsnag_flutter_performance/src/util/clock.dart';
 import 'package:bugsnag_flutter_performance/src/widgets/widget_instrumentation_node_provider.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 class MeasuredWidget extends StatefulWidget {
@@ -62,6 +63,11 @@ class _MeasuredWidgetContent extends StatefulWidget {
 
   @override
   State<_MeasuredWidgetContent> createState() => _MeasuredWidgetContentState();
+
+  @override
+  StatefulElement createElement() {
+    return _MeasuredWidgetContentElement(this);
+  }
 }
 
 class _MeasuredWidgetContentState extends State<_MeasuredWidgetContent> {
@@ -77,11 +83,27 @@ class _MeasuredWidgetContentState extends State<_MeasuredWidgetContent> {
       state: _state!,
       context: context,
     );
-    final content = widget.builder(context);
+    return widget.builder(context);
+  }
+}
+
+class _MeasuredWidgetContentElement extends StatefulElement {
+  _MeasuredWidgetContentElement(super.widget);
+
+  var didBuild = false;
+
+  @override
+  Element? updateChild(Element? child, Widget? newWidget, Object? newSlot) {
+    final result = super.updateChild(child, newWidget, newSlot);
+    final instrumentationState = (state as _MeasuredWidgetContentState)._state;
+    if (didBuild || instrumentationState == null) {
+      return result;
+    }
     measuredWidgetCallbacks.didBuildWidget(
-      state: _state!,
-      context: context,
+      state: instrumentationState,
+      context: this,
     );
-    return content;
+    didBuild = true;
+    return result;
   }
 }

--- a/packages/bugsnag_flutter_performance/lib/src/widgets/measured_widget.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/widgets/measured_widget.dart
@@ -1,0 +1,87 @@
+import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_node.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_state.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/view_load/measured_widget_callbacks.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/view_load/view_load_instrumentation_state.dart';
+import 'package:bugsnag_flutter_performance/src/util/clock.dart';
+import 'package:bugsnag_flutter_performance/src/widgets/widget_instrumentation_node_provider.dart';
+import 'package:flutter/widgets.dart';
+
+class MeasuredWidget extends StatefulWidget {
+  const MeasuredWidget({
+    super.key,
+    required this.name,
+    required this.builder,
+  });
+
+  final String name;
+  final Widget Function(BuildContext) builder;
+
+  @override
+  State<MeasuredWidget> createState() => _MeasuredWidgetState();
+}
+
+class _MeasuredWidgetState extends State<MeasuredWidget> {
+  WidgetInstrumentationNode? _currentNode;
+
+  @override
+  Widget build(BuildContext context) {
+    _currentNode?.dispose();
+    final parentNode = WidgetInstrumentationNode.of(context);
+    final newNode = WidgetInstrumentationNode(
+      state: WidgetInstrumentationState(
+        name: widget.name,
+        startTime: BugsnagClockImpl.instance.now(),
+      ),
+    );
+    _currentNode = newNode;
+    parentNode.addChild(newNode);
+    return WidgetInstrumentationNodeProvider(
+      node: newNode,
+      child: _MeasuredWidgetContent(
+        name: widget.name,
+        builder: widget.builder,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _currentNode?.dispose();
+    super.dispose();
+  }
+}
+
+class _MeasuredWidgetContent extends StatefulWidget {
+  const _MeasuredWidgetContent({
+    required this.name,
+    required this.builder,
+  });
+
+  final String name;
+  final Widget Function(BuildContext) builder;
+
+  @override
+  State<_MeasuredWidgetContent> createState() => _MeasuredWidgetContentState();
+}
+
+class _MeasuredWidgetContentState extends State<_MeasuredWidgetContent> {
+  ViewLoadInstrumentationState? _state;
+
+  @override
+  Widget build(BuildContext context) {
+    _state ??= ViewLoadInstrumentationState(
+      name: widget.name,
+      startTime: BugsnagClockImpl.instance.now(),
+    );
+    measuredWidgetCallbacks.willBuildWidget(
+      state: _state!,
+      context: context,
+    );
+    final content = widget.builder(context);
+    measuredWidgetCallbacks.didBuildWidget(
+      state: _state!,
+      context: context,
+    );
+    return content;
+  }
+}

--- a/packages/bugsnag_flutter_performance/lib/src/widgets/widget_instrumentation_node_provider.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/widgets/widget_instrumentation_node_provider.dart
@@ -1,8 +1,8 @@
-import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/navigation_instrumentation_node.dart';
+import 'package:bugsnag_flutter_performance/src/instrumentation/navigation/widget_instrumentation_node.dart';
 import 'package:flutter/widgets.dart';
 
-class NavigationInstrumentationNodeProvider extends InheritedWidget {
-  const NavigationInstrumentationNodeProvider({
+class WidgetInstrumentationNodeProvider extends InheritedWidget {
+  const WidgetInstrumentationNodeProvider({
     super.key,
     required this.node,
     required super.child,
@@ -12,7 +12,7 @@ class NavigationInstrumentationNodeProvider extends InheritedWidget {
 
   @override
   bool updateShouldNotify(
-      covariant NavigationInstrumentationNodeProvider oldWidget) {
+      covariant WidgetInstrumentationNodeProvider oldWidget) {
     return oldWidget.node != node;
   }
 }


### PR DESCRIPTION
## Goal

This allows the User to track individual widgets building, appearing and loading performance

## Design

`MeasuredWidget` is used to add phased view load tracking to a widget builder

## Changeset

New public widget was introduced: `MeasuredWidget`

## Testing

E2E tests