### PR TITLE
fix for flakey test

### DIFF
--- a/features/persistence.feature
+++ b/features/persistence.feature
@@ -5,11 +5,11 @@ Background:
 
   Scenario: Device Id Persists Between Launches
     When I run "ManualSpanScenario"
+    * I wait to receive a trace
     * I relaunch the app
     * I run "ManualSpanScenario"
     * I wait to receive 2 traces
     * every trace deviceid is valid and the same
-
 
   Scenario: Receive a persisted trace
     When I set the HTTP status code to 408


### PR DESCRIPTION
## Goal

Fix E2E race condition where appium shut down the device before the initial span had been delivered.

