### PR TITLE
migrated device_info to device_info_plus

### DIFF
--- a/packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart
@@ -1,5 +1,5 @@
-import 'package:device_info/device_info.dart';
 import 'dart:io';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:package_info/package_info.dart';
 import 'package:bugsnag_flutter_performance/src/device_id_manager.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';

--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  device_info: ^2.0.3
+  device_info_plus: ^10.1.0
   package_info: ^2.0.2
   path_provider: ^2.0.2
   uuid: ^4.0.0


### PR DESCRIPTION
## Goal

Device info package is discontinued. Migrate to Device info plus.

## Design

<!-- Why was this approach used? -->
For new gradle plugins, namespace is required. 
A problem occurred configuring project ':device_info'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

## Changeset

<!-- What changed? -->
Specify a namespace is mandatory now.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->