### PR TITLE
Ensure connection between ViewLoad instrumentation and Navigation instrumentation spans

### DIFF
--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -240,3 +240,45 @@ Feature: Automatic instrumentation spans
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/building"
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/appearing"
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading"
+
+  Scenario: AutoInstrumentNavigationWithViewLoadScenario
+    Given I run "AutoInstrumentNavigationWithViewLoadScenario"
+    And I wait for 3 seconds
+    * no span named "[Navigation]navigation_view_load_scenario" exists
+    * no span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" exists
+    Then I invoke "step2"
+    And I wait for 3 seconds
+    * no span named "[Navigation]navigation_view_load_scenario" exists
+    * no span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" exists
+    Then I invoke "step3"
+    And I wait for 3 seconds
+    * no span named "[Navigation]navigation_view_load_scenario" exists
+    * no span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" exists
+    Then I invoke "step4"
+    And I wait for 5 spans
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * a span field "name" equals "[Navigation]navigation_view_load_scenario"
+    * a span string attribute "bugsnag.navigation.route" equals "navigation_view_load_scenario"
+    * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
+    * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
+    * a span string attribute "bugsnag.navigation.previous_route" equals "/"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/building"
+    * a span string attribute "bugsnag.phase" equals "building"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/appearing"
+    * a span string attribute "bugsnag.phase" equals "appearing"
+    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/loading"
+    * a span string attribute "bugsnag.phase" equals "loading"
+    * a span string attribute "bugsnag.span.category" equals "view_load_phase"
+    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget"
+    * a span string attribute "bugsnag.span.category" equals "view_load"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" does not exist
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/building"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/appearing"
+    * the span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/loading"
+    * the span named "[Navigation]navigation_view_load_scenario" is the parent of the span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget"

--- a/features/fixture_resources/lib/scenarios/auto_instrument_navigation_with_view_load_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_navigation_with_view_load_scenario.dart
@@ -1,0 +1,114 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+import 'package:flutter/material.dart';
+import 'package:mazerunner/main.dart';
+
+import 'scenario.dart';
+
+class AutoInstrumentNavigationWithViewLoadScenario extends Scenario {
+  final _key =
+      GlobalKey<_AutoInstrumentNavigationWithViewLoadScenarioScreenState>();
+
+  @override
+  Future<void> run() async {
+    setInstrumentsNavigation(true);
+    setInstrumentsViewLoad(true);
+    await startBugsnag();
+    setMaxBatchSize(1);
+  }
+
+  @override
+  Widget? createWidget() {
+    return AutoInstrumentNavigationWithViewLoadScenarioScreen(
+      key: _key,
+      runCommandCallback: () => runCommandCallback!(),
+    );
+  }
+
+  @override
+  RouteSettings? routeSettings() {
+    return const RouteSettings(name: 'navigation_view_load_scenario');
+  }
+
+  void step2() {
+    _key.currentState!.setStage(2);
+  }
+
+  void step3() {
+    _key.currentState!.setStage(3);
+  }
+
+  void step4() {
+    _key.currentState!.setStage(4);
+  }
+
+  @override
+  void invokeMethod(String name) {
+    switch (name) {
+      case 'step2':
+        step2();
+        break;
+      case 'step3':
+        step3();
+        break;
+      case 'step4':
+        step4();
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+class AutoInstrumentNavigationWithViewLoadScenarioScreen
+    extends StatefulWidget {
+  const AutoInstrumentNavigationWithViewLoadScenarioScreen({
+    super.key,
+    required this.runCommandCallback,
+  });
+  final void Function() runCommandCallback;
+
+  @override
+  State<AutoInstrumentNavigationWithViewLoadScenarioScreen> createState() =>
+      _AutoInstrumentNavigationWithViewLoadScenarioScreenState();
+}
+
+class _AutoInstrumentNavigationWithViewLoadScenarioScreenState
+    extends State<AutoInstrumentNavigationWithViewLoadScenarioScreen> {
+  var _stage = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+        child: Container(
+            color: Colors.white,
+            child: MeasuredWidget(
+              name: 'AutoInstrumentNavigationWithViewLoadWidget',
+              builder: (context) => Row(
+                children: [
+                  if (_stage < 4)
+                    BugsnagLoadingIndicator(
+                      child: Column(children: [
+                        if (_stage < 3)
+                          const BugsnagLoadingIndicator(
+                            child: Text('Still loading...'),
+                          ),
+                        if (_stage < 2)
+                          const BugsnagLoadingIndicator(
+                            child: CircularProgressIndicator(),
+                          )
+                      ]),
+                    ),
+                  const Text(
+                      'AutoInstrumentNavigationWithViewLoadScenarioScreen')
+                ],
+              ),
+            )),
+        onTap: () => widget.runCommandCallback());
+  }
+
+  void setStage(int stage) {
+    setState(() {
+      _stage = stage;
+    });
+  }
+}

--- a/features/fixture_resources/lib/scenarios/scenarios.dart
+++ b/features/fixture_resources/lib/scenarios/scenarios.dart
@@ -8,6 +8,7 @@ import 'package:mazerunner/scenarios/auto_instrument_view_load_basic_scenario.da
 import 'package:mazerunner/scenarios/auto_instrument_view_load_nested_scenario.dart';
 
 import 'auto_instrument_app_starts_scenario.dart';
+import 'auto_instrument_navigation_with_view_load_scenario.dart';
 import 'dio_callback_cancel_span.dart';
 import 'dio_callback_edit_scenario.dart';
 import 'initial_p_scenario.dart';
@@ -104,4 +105,6 @@ final List<ScenarioInfo<Scenario>> scenarios = [
       () => AutoInstrumentViewLoadBasicDeferScenario()),
   ScenarioInfo('AutoInstrumentViewLoadNestedScenario',
       () => AutoInstrumentViewLoadNestedScenario()),
+  ScenarioInfo('AutoInstrumentNavigationWithViewLoadScenario',
+      () => AutoInstrumentNavigationWithViewLoadScenario()),
 ];

--- a/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/view_load_instrumentation.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/instrumentation/view_load/view_load_instrumentation.dart
@@ -41,8 +41,10 @@ class ViewLoadInstrumentationImpl implements ViewLoadInstrumentation {
     if (!_enabled || state.viewLoadSpan != null) {
       return;
     }
+    final node = WidgetInstrumentationNode.of(context);
     final viewLoadSpan = client.startViewLoadSpan(
       viewName: state.name,
+      parentContext: node.state?.nearestNavigationSpan(),
     );
     state.viewLoadSpan = viewLoadSpan;
     state.buildingSpan = client.startViewLoadPhaseSpan(


### PR DESCRIPTION

## Goal

Make sure that view load span has the nearest open navigation span in the widget tree set as its parent

## Testing

E2E tests