### PR TITLE
Move Android  job back to BitBar

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,7 +81,7 @@ steps:
         upload:
           - "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
 
-  - label: ':browserstack: Android 12 end-to-end tests 3.10.0'
+  - label: ':bitbar: Android 12 end-to-end tests 3.10.0'
     depends_on: "android-fixture-3-10-0"
     timeout_in_minutes: 20
     env:
@@ -99,11 +99,11 @@ steps:
         service-ports: true
         command:
           - "--app=features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_12"
+          - "--farm=bb"
+          - "--device=ANDROID_10|ANDROID_11|ANDROID_12|ANDROID_13"
           - "--no-tunnel"
           - "--aws-public-ip"
-          - "--appium-version=1.22.0"
+          - "--appium-version=1.22"
           - "--fail-fast"
     concurrency: 25
     concurrency_group: 'browserstack-app'


### PR DESCRIPTION
## Goal

Move the e2e tests for Android back to BitBar.

## Design

This change also settles the Appium version on 1.22.  The original build would have been Appium 2 and I believe that was the reason the tests were failing on BitBar (Appium 2 inherently unstable there for us it seems).

## Testing

Covered by CI, although there appears to be a persistent failure in `Scenario: Device Id Persists Between Launches` - perhaps relating to the change that this PR is based upon?