### PR TITLE
Send service.name in resource attributes

### DIFF
--- a/features/fixture_resources/lib/scenarios/custom_service_name_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_service_name_scenario.dart
@@ -1,0 +1,11 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+import 'scenario.dart';
+
+class CustomServiceNameScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await startBugsnag(serviceName: "com.custom.serviceName");
+    setMaxBatchSize(1);
+    doSimpleSpan('CustomServiceNameScenario');
+  }
+}

--- a/features/fixture_resources/lib/scenarios/scenario.dart
+++ b/features/fixture_resources/lib/scenarios/scenario.dart
@@ -45,6 +45,7 @@ abstract class Scenario {
     String? releaseStage,
     List<String>? enabledReleaseStages,
     List<RegExp>? tracePropagationUrls,
+    String? serviceName,
     String? appVersion,
     bool shouldUseNotifier = false,
     double? samplingProbability,
@@ -57,6 +58,7 @@ abstract class Scenario {
       releaseStage: releaseStage,
       enabledReleaseStages: enabledReleaseStages,
       tracePropagationUrls: tracePropagationUrls,
+      serviceName: serviceName,
       appVersion: appVersion,
       samplingProbability: samplingProbability,
     );

--- a/features/fixture_resources/lib/scenarios/scenarios.dart
+++ b/features/fixture_resources/lib/scenarios/scenarios.dart
@@ -8,6 +8,7 @@ import 'package:mazerunner/scenarios/auto_instrument_view_load_basic_scenario.da
 import 'package:mazerunner/scenarios/auto_instrument_view_load_nested_scenario.dart';
 import 'package:mazerunner/scenarios/correlation_null_scenario.dart';
 import 'package:mazerunner/scenarios/correlation_simple_scenario.dart';
+import 'package:mazerunner/scenarios/custom_service_name_scenario.dart';
 import 'package:mazerunner/scenarios/dart_io_traceparent_scenario.dart';
 import 'package:mazerunner/scenarios/fixed_sampling_probability_one_scenario.dart';
 import 'package:mazerunner/scenarios/fixed_sampling_probability_zero_scenario.dart';
@@ -125,4 +126,5 @@ final List<ScenarioInfo<Scenario>> scenarios = [
       () => FixedSamplingProbabilityOneScenario()),
   ScenarioInfo('FixedSamplingProbabilityZeroScenario',
       () => FixedSamplingProbabilityZeroScenario()),
+  ScenarioInfo('CustomServiceNameScenario', () => CustomServiceNameScenario()),
 ];

--- a/features/resource_attributes.feature
+++ b/features/resource_attributes.feature
@@ -18,6 +18,15 @@ Feature: Resource Attributes
     * every span field "name" equals "CustomEnabledReleaseStageScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "CustomEnabledReleaseStageScenario"
 
+  Scenario: Custom service name
+    When I run "CustomServiceNameScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * every span field "name" equals "CustomServiceNameScenario"
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.custom.serviceName"
+
   Scenario: Custom app version
     When I run "CustomAppVersionScenario"
     And I wait for 1 span
@@ -46,6 +55,7 @@ Feature: Resource Attributes
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.flutter"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.version" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "device.model.identifier" exists
+    * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.bugsnag.mazerunner"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "1.0.0"
     * the trace payload field "resourceSpans.0.resource" string attribute "device.manufacturer" exists
     * the trace payload field "resourceSpans.0.resource" string attribute "host.arch" exists

--- a/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
+++ b/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
@@ -41,6 +41,7 @@ class BugsnagPerformance {
     String? releaseStage,
     List<String>? enabledReleaseStages,
     List<RegExp>? tracePropagationUrls,
+    String? serviceName,
     String? appVersion,
     double? samplingProbability,
   }) {
@@ -52,6 +53,7 @@ class BugsnagPerformance {
       releaseStage: releaseStage,
       enabledReleaseStages: enabledReleaseStages,
       tracePropagationUrls: tracePropagationUrls,
+      serviceName: serviceName,
       appVersion: appVersion,
       samplingProbability: samplingProbability,
     );

--- a/packages/bugsnag_flutter_performance/lib/src/client.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/client.dart
@@ -37,6 +37,7 @@ abstract class BugsnagPerformanceClient {
         networkRequestCallback,
     String? releaseStage,
     List<String>? enabledReleaseStages,
+    String? serviceName,
     String? appVersion,
   });
 
@@ -131,6 +132,7 @@ class BugsnagPerformanceClientImpl implements BugsnagPerformanceClient {
     String? releaseStage,
     List<String>? enabledReleaseStages,
     List<RegExp>? tracePropagationUrls,
+    String? serviceName,
     String? appVersion,
     double? samplingProbability,
   }) async {
@@ -147,6 +149,7 @@ class BugsnagPerformanceClientImpl implements BugsnagPerformanceClient {
       releaseStage: releaseStage ?? getDeploymentEnvironment(),
       enabledReleaseStages: enabledReleaseStages,
       tracePropagationUrls: tracePropagationUrls,
+      serviceName: serviceName,
       appVersion: appVersion,
       samplingProbability: samplingProbability,
     );

--- a/packages/bugsnag_flutter_performance/lib/src/configuration.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/configuration.dart
@@ -5,6 +5,7 @@ class BugsnagPerformanceConfiguration {
     this.releaseStage,
     this.enabledReleaseStages,
     this.tracePropagationUrls,
+    this.serviceName,
     this.appVersion,
     this.samplingProbability,
   });
@@ -20,6 +21,7 @@ class BugsnagPerformanceConfiguration {
   List<RegExp>? tracePropagationUrls;
   String? releaseStage;
   List<String>? enabledReleaseStages;
+  String? serviceName;
   String? appVersion;
   double? samplingProbability;
 

--- a/packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart
@@ -83,6 +83,12 @@ class ResourceAttributesProviderImpl implements ResourceAttributesProvider {
         }
       },
       {
+        "key": "service.name",
+        "value": {
+          "stringValue": config?.serviceName ?? packageInfo.packageName,
+        }
+      },
+      {
         "key": "service.version",
         "value": {
           "stringValue": config?.appVersion ?? packageInfo.version,


### PR DESCRIPTION
## Goal

We need to send service.name in resource attributes as we already do in Cocoa and Android.
User should also be able to override the default value.

## Testing

E2E tests