### PR TITLE
Updated default url

### DIFF
--- a/packages/bugsnag_flutter_performance/lib/src/client.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/client.dart
@@ -27,7 +27,8 @@ import 'bugsnag_network_request_info.dart';
 import 'configuration.dart';
 import 'span.dart';
 
-const _defaultEndpoint = 'https://otlp.bugsnag.com/v1/traces';
+String _defaultEndpoint(String? apiKey) =>
+    'https://${apiKey != null ? '$apiKey.' : ''}otlp.bugsnag.com/v1/traces';
 
 abstract class BugsnagPerformanceClient {
   Future<void> start({
@@ -143,7 +144,7 @@ class BugsnagPerformanceClientImpl implements BugsnagPerformanceClient {
     _networkRequestCallback = networkRequestCallback;
     configuration = BugsnagPerformanceConfiguration(
       apiKey: apiKey,
-      endpoint: endpoint ?? Uri.parse(_defaultEndpoint),
+      endpoint: endpoint ?? Uri.parse(_defaultEndpoint(apiKey)),
       releaseStage: releaseStage ?? getDeploymentEnvironment(),
       enabledReleaseStages: enabledReleaseStages,
       tracePropagationUrls: tracePropagationUrls,

--- a/packages/bugsnag_flutter_performance/test/src/client_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/client_test.dart
@@ -42,6 +42,10 @@ class MockLifecycleListener implements BugsnagLifecycleListener {
 void main() {
   const apiKey = 'TestApiKey';
   final endpoint = Uri.tryParse('https://bugsnag.com')!;
+  final defaultEndpointWithoutApiKey =
+      Uri.tryParse('https://otlp.bugsnag.com/v1/traces');
+  final defaultEndpointWithApiKey =
+      Uri.tryParse('https://$apiKey.otlp.bugsnag.com/v1/traces');
   BugsnagClockImpl.ensureInitialized();
   group('BugsnagPerformanceClient', () {
     late BugsnagPerformanceClientImpl client;
@@ -56,6 +60,23 @@ void main() {
         await client.start(apiKey: apiKey, endpoint: endpoint);
         expect(client.configuration!.apiKey, equals(apiKey));
         expect(client.configuration!.endpoint, equals(endpoint));
+      });
+
+      test(
+          'should set configuration with the correct default endpoint when apiKey is present',
+          () async {
+        await client.start(apiKey: apiKey);
+        expect(client.configuration!.apiKey, equals(apiKey));
+        expect(
+            client.configuration!.endpoint, equals(defaultEndpointWithApiKey));
+      });
+
+      test(
+          'should set configuration with the correct default endpoint when apiKey is not present',
+          () async {
+        await client.start();
+        expect(client.configuration!.endpoint,
+            equals(defaultEndpointWithoutApiKey));
       });
     });
 


### PR DESCRIPTION
## Goal

Our SaaS span endpoint now supports the format <project_api_key>.otlp.bugsnag.com. We can now roll this out across our RUM SDKs.

## Testing

E2E tests