### PR TITLE
Fixed PathNotFoundException thrown when retry queue flush is triggered multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
 
 ### Bug fixes
 
+* Fixed PathNotFoundException thrown when retry queue flush is triggered multiple times [82](https://github.com/bugsnag/bugsnag-flutter-performance/pull/82)
+
 * The correct package version is reported in the `telemetry.sdk.version` attribute [83](https://github.com/bugsnag/bugsnag-flutter-performance/pull/83)
 
 ## 1.1.0 (2024-08-14)

--- a/packages/bugsnag_flutter_performance/lib/src/client.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/client.dart
@@ -297,7 +297,7 @@ class BugsnagPerformanceClientImpl implements BugsnagPerformanceClient {
     if (result == RequestResult.retriableFailure) {
       _retryQueue?.enqueue(headers: package.headers, body: package.payload);
     } else if (result == RequestResult.success) {
-      _retryQueue?.flush();
+      await _retryQueue?.flush();
     }
   }
 

--- a/packages/bugsnag_flutter_performance/lib/src/uploader/retry_queue.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/uploader/retry_queue.dart
@@ -65,12 +65,12 @@ class FileRetryQueue implements RetryQueue {
       return;
     }
     _isFlushing = true;
-    try {
-      final files = cacheDirectory.listSync().cast<File>()
-        ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
+    final files = cacheDirectory.listSync().cast<File>()
+      ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
 
-      final now = BugsnagClockImpl.instance.now();
-      for (var file in files) {
+    final now = BugsnagClockImpl.instance.now();
+    for (var file in files) {
+      try {
         if (now.difference(file.lastModifiedSync()) > _maxAge) {
           file.deleteSync();
         } else {
@@ -82,9 +82,13 @@ class FileRetryQueue implements RetryQueue {
             file.deleteSync();
           }
         }
+      } catch (error) {
+        try {
+          file.deleteSync();
+        } catch (_) {
+          // deliberately ignored
+        }
       }
-    } catch (error) {
-      // deliberately ignored
     }
     _isFlushing = false;
   }

--- a/packages/bugsnag_flutter_performance/lib/src/uploader/retry_queue.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/uploader/retry_queue.dart
@@ -43,6 +43,7 @@ class FileRetryQueue implements RetryQueue {
   static const Duration _maxAge = Duration(hours: 24);
 
   final Uploader? _uploader;
+  var _isFlushing = false;
 
   FileRetryQueue(Uploader uploader) : _uploader = uploader;
 
@@ -60,27 +61,32 @@ class FileRetryQueue implements RetryQueue {
   @override
   Future<void> flush() async {
     final cacheDirectory = await _getCacheDirectory();
-    if (!cacheDirectory.existsSync()) {
+    if (_isFlushing || !cacheDirectory.existsSync()) {
       return;
     }
+    _isFlushing = true;
+    try {
+      final files = cacheDirectory.listSync().cast<File>()
+        ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
 
-    final files = cacheDirectory.listSync().cast<File>()
-      ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
-
-    final now = BugsnagClockImpl.instance.now();
-    for (var file in files) {
-      if (now.difference(file.lastModifiedSync()) > _maxAge) {
-        file.deleteSync();
-      } else {
-        final payload = await file.readAsString();
-        final cachedPayloadModel =
-            CachedPayloadModel.fromJson(jsonDecode(payload));
-        final success = await _sendPayload(cachedPayloadModel);
-        if (success) {
+      final now = BugsnagClockImpl.instance.now();
+      for (var file in files) {
+        if (now.difference(file.lastModifiedSync()) > _maxAge) {
           file.deleteSync();
+        } else {
+          final payload = await file.readAsString();
+          final cachedPayloadModel =
+              CachedPayloadModel.fromJson(jsonDecode(payload));
+          final success = await _sendPayload(cachedPayloadModel);
+          if (success) {
+            file.deleteSync();
+          }
         }
       }
+    } catch (error) {
+      // deliberately ignored
     }
+    _isFlushing = false;
   }
 
   Future<bool> _sendPayload(CachedPayloadModel payloadModel) async {

--- a/packages/bugsnag_flutter_performance/lib/src/uploader/span_batch.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/uploader/span_batch.dart
@@ -17,7 +17,7 @@ class SpanBatchImpl implements SpanBatch {
   int _maxBatchSize = 0;
   int _maxBatchAge = 0;
   bool _drainIsAllowed = false;
-  final DateTime _creationTime = DateTime.now();
+  DateTime _creationTime = DateTime.now();
 
   @override
   void Function(SpanBatch batch) onBatchFull = (_) {};
@@ -53,6 +53,8 @@ class SpanBatchImpl implements SpanBatch {
     }
     final spans = _spans.toList();
     _spans.clear();
+    _creationTime = DateTime.now();
+    _drainIsAllowed = false;
     return spans;
   }
 
@@ -75,6 +77,9 @@ class SpanBatchImpl implements SpanBatch {
   bool get _isFull => _spans.length >= _maxBatchSize;
 
   void _checkForMaxBatchAge() {
+    if (_isFull) {
+      return;
+    }
     if (DateTime.now().difference(_creationTime).inMilliseconds >
         _maxBatchAge) {
       _drainIsAllowed = true;

--- a/packages/bugsnag_flutter_performance/test/src/uploader/span_batch_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/uploader/span_batch_test.dart
@@ -202,6 +202,56 @@ void main() {
             equals([span]),
           );
         });
+
+        test(
+            'should return empty list again if the batch was previously drained, is not full and it is not forced',
+            () {
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.drain();
+
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          expect(batch.drain().length, equals(0));
+        });
+
+        test(
+            'should return all spans if the batch was drained and is full again',
+            () {
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.add(
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now()));
+          batch.drain();
+
+          final span1 =
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now());
+          final span2 =
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now());
+          final span3 =
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now());
+          final span4 =
+              BugsnagPerformanceSpanImpl(name: '', startTime: DateTime.now());
+          batch.add(span1);
+          batch.add(span2);
+          batch.add(span3);
+          batch.add(span4);
+
+          expect(
+            batch.drain(),
+            equals([span1, span2, span3, span4]),
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## Goal

PathNotFoundException is thrown when retry queue flush is triggered multiple times concurrently

## Changeset

Implemented necessary safeguards

## Testing

Existing tests