### PR TITLE
Flutter Performance reporting wrong notifier version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 * A fixed `samplingProbability` can now be set on `start` [78](https://github.com/bugsnag/bugsnag-flutter-performance/pull/78)
 
+### Bug fixes
+
+* The correct package version is reported in the `telemetry.sdk.version` attribute [83](https://github.com/bugsnag/bugsnag-flutter-performance/pull/83)
+
 ## 1.1.0 (2024-08-14)
 
 ### Enhancements

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ endif
 	@echo $(VERSION) > VERSION
 	sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
 	sed -i '' "s/^version: .*/version: $(VERSION)/" packages/bugsnag_flutter_performance/pubspec.yaml
+	sed -i '' "s/^  static String get _getSDKVersion => .*/  static String get _getSDKVersion => '$(VERSION)';/" packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart
 	
 publish_dry:
 	cd staging/bugsnag_flutter_performance && $(FLUTTER_BIN) pub publish --dry-run
@@ -61,7 +62,7 @@ ifeq ($(VERSION),)
 endif
 	rm -rf staging
 	@git checkout -b release-v$(VERSION)
-	@git add packages/bugsnag_flutter_performance/pubspec.yaml CHANGELOG.md VERSION
+	@git add packages/bugsnag_flutter_performance/pubspec.yaml packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart CHANGELOG.md VERSION
 	@git diff --exit-code || (echo "you have unstaged changes - Makefile may need updating to `git add` some more files"; exit 1)
 	@git commit -m "Release v$(VERSION)"
 	@git push origin release-v$(VERSION)

--- a/packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/extensions/resource_attributes.dart
@@ -73,7 +73,7 @@ class ResourceAttributesProviderImpl implements ResourceAttributesProvider {
       {
         'key': 'telemetry.sdk.version',
         'value': {
-          'stringValue': '0.0.1',
+          'stringValue': _getSDKVersion,
         }
       },
       {
@@ -195,4 +195,6 @@ class ResourceAttributesProviderImpl implements ResourceAttributesProvider {
     }
     return "Unknown";
   }
+
+  static String get _getSDKVersion => '1.1.0';
 }


### PR DESCRIPTION
## Goal

Set the correct package version in the `telemetry.sdk.version` attribute

## Changeset

Updated Makefile to edit the hardcoded package version in resource_attributes.dart