### PR TITLE
Fixed an exception thrown when no source of cryptographically secure random numbers is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fixed an exception thrown when no source of cryptographically secure random numbers is available [85](https://github.com/bugsnag/bugsnag-flutter-performance/pull/85)
+
 ## 1.2.0 (2024-09-13)
 
 ### Enhancements

--- a/packages/bugsnag_flutter_performance/lib/src/util/random.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/util/random.dart
@@ -9,11 +9,35 @@ BigInt randomTraceId() {
 }
 
 BigInt randomValue(int length) {
-  final random = Random.secure();
+  final random = _Random();
   BigInt result = BigInt.from(random.nextInt(256) & 0xff);
   for (var i = 1; i < length; i++) {
     int byte = random.nextInt(256);
     result = (result << 8) | BigInt.from(byte & 0xff);
   }
   return result;
+}
+
+class _Random {
+  static final _sharedRandom = Random();
+  late final Random? _secureRandom;
+
+  _Random() {
+    try {
+      _secureRandom = Random.secure();
+    } catch (e) {
+      // deliberately ignored
+    }
+  }
+
+  int nextInt(int max) {
+    try {
+      if (_secureRandom != null) {
+        return _secureRandom!.nextInt(max);
+      }
+    } catch (e) {
+      // deliberately ignored
+    }
+    return _sharedRandom.nextInt(max);
+  }
 }


### PR DESCRIPTION
## Goal

Handle UnsupportedError that is thrown if the platform doesn't provide any source of secure random numbers

## Testing

Existing tests