### PR TITLE
Ensure traceIds are generated with most secure random generator available

### DIFF
--- a/packages/bugsnag_flutter_performance/lib/src/util/random.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/util/random.dart
@@ -1,15 +1,15 @@
 import 'dart:math';
 
 BigInt randomSpanId() {
-  return randomValue(8);
+  return randomValue(8, false);
 }
 
 BigInt randomTraceId() {
-  return randomValue(16);
+  return randomValue(16, true);
 }
 
-BigInt randomValue(int length) {
-  final random = _Random();
+BigInt randomValue(int length, bool secure) {
+  final random = _Random(secure);
   BigInt result = BigInt.from(random.nextInt(256) & 0xff);
   for (var i = 1; i < length; i++) {
     int byte = random.nextInt(256);
@@ -19,14 +19,17 @@ BigInt randomValue(int length) {
 }
 
 class _Random {
-  static final _sharedRandom = Random();
+  static final _sharedRandom = _createSharedRandom();
   late final Random? _secureRandom;
+  final bool secure;
 
-  _Random() {
+  _Random(this.secure) {
     try {
-      _secureRandom = Random.secure();
-    } catch (e) {
-      // deliberately ignored
+      if (secure) {
+        _secureRandom = Random.secure();
+      }
+    } catch (_) {
+      // If the platform doesn't provide a secure random source then we fall back on a less secure version
     }
   }
 
@@ -35,9 +38,19 @@ class _Random {
       if (_secureRandom != null) {
         return _secureRandom!.nextInt(max);
       }
-    } catch (e) {
-      // deliberately ignored
+    } catch (_) {
+      // When the system runs out of entropy, we fall back on a less secure random number source
+      // Although the documentation doesn't mention it, nextInt can throw
     }
     return _sharedRandom.nextInt(max);
+  }
+
+  static Random _createSharedRandom() {
+    try {
+      final secureRandom = Random.secure();
+      return Random(secureRandom.nextInt(1 << 32));
+    } catch (_) {
+      return Random();
+    }
   }
 }


### PR DESCRIPTION
## Goal

Ensure traceIds are generated with most secure random generator available

## Design

Secure random generator throws an undocumented error on nextInt() when the system runs out of entropy to generate the next number. In addition to catching the error and using a fallback, we need to ensure that traceIds will be generated with the most secure random generator available at the time.
In order to achieve that, only traceIds will be generated by Random.secure() implementation.
SpanIds will be generated by a default Random implementation with a secure seed. This will not deplete the entropy needed to keep generating secure spanIds. 

## Changeset

- Introduced three levels of quality of random generator that we use: Random.secure(), shared Random with a secure seed, shared Random with a system-generated seed
- TraceIds are generated with Random.secure() whenever possible with fallbacks to lower quality levels
- SpanIds are generated with a shared Random with a secure seed with fallback to lower quality level

## Testing

Existing E2E tests