### PR TITLE
Allow User to set custom attributes for a span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Custom attributes can now be set on a span, including as lists of primitives (int, double, bool, String) [88](https://github.com/bugsnag/bugsnag-flutter-performance/pull/88)
+
 ## 1.2.1 (2024-09-18)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 * Custom attributes can now be set on a span, including as lists of primitives (int, double, bool, String) [88](https://github.com/bugsnag/bugsnag-flutter-performance/pull/88)
 
+* Introduced OnSpanEndCallbacks that allow changes to spans when their end() method is called, but before they are sent [88](https://github.com/bugsnag/bugsnag-flutter-performance/pull/88)
+
 ## 1.2.1 (2024-09-18)
 
 ### Bug fixes

--- a/features/fixture_resources/lib/channels.dart
+++ b/features/fixture_resources/lib/channels.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:flutter/services.dart';
 
 class MazeRunnerChannels {

--- a/features/fixture_resources/lib/main.dart
+++ b/features/fixture_resources/lib/main.dart
@@ -84,7 +84,7 @@ class Command {
 }
 
 class MazeRunnerFlutterApp extends StatelessWidget {
-  const MazeRunnerFlutterApp({Key? key}) : super(key: key);
+  const MazeRunnerFlutterApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -151,9 +151,9 @@ class MazeRunnerHomePage extends StatefulWidget {
   final String mazerunnerUrl;
 
   const MazeRunnerHomePage({
-    Key? key,
+    super.key,
     required this.mazerunnerUrl,
-  }) : super(key: key);
+  });
 
   @override
   State<MazeRunnerHomePage> createState() => _HomePageState();
@@ -332,9 +332,9 @@ class _HomePageState extends State<MazeRunnerHomePage> {
                 height: 400.0,
                 width: double.infinity,
                 child: TextButton(
-                  child: const Text("Run Command"),
                   onPressed: () => _onRunCommand(context),
                   key: const Key("runCommand"),
+                  child: const Text("Run Command"),
                 ),
               ),
               TextField(
@@ -373,14 +373,14 @@ class _HomePageState extends State<MazeRunnerHomePage> {
                 ),
               ),
               TextButton(
-                child: const Text("Start Bugsnag"),
                 onPressed: _onStartBugsnag,
                 key: const Key("startBugsnag"),
+                child: const Text("Start Bugsnag"),
               ),
               TextButton(
-                child: const Text("Run Scenario"),
                 onPressed: () => _onRunScenario(context),
                 key: const Key("startScenario"),
+                child: const Text("Run Scenario"),
               ),
             ],
           ),

--- a/features/fixture_resources/lib/scenarios/auto_instrument_app_starts_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_app_starts_scenario.dart
@@ -10,8 +10,8 @@ class AutoInstrumentAppStartsScenario extends Scenario {
     bugsnag_performance.setExtraConfig("probabilityValueExpireTime", 1000);
     bugsnag_performance.start(
         apiKey: '12312312312312312312312312312312',
-        endpoint: Uri.parse(FixtureConfig.MAZE_HOST.toString() + '/traces'));
-    bugsnag_performance.measureRunApp(() async => await Duration(seconds: 1));
+        endpoint: Uri.parse('${FixtureConfig.MAZE_HOST}/traces'));
+    bugsnag_performance.measureRunApp(() async => const Duration(seconds: 1));
     setMaxBatchSize(4);
   }
 }

--- a/features/fixture_resources/lib/scenarios/auto_instrument_navigation_basic_defer_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_navigation_basic_defer_scenario.dart
@@ -1,6 +1,5 @@
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:flutter/material.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 
@@ -68,7 +67,7 @@ class _AutoInstrumentNavigationBasicDeferScenarioScreenState
         onTap: () => widget.runCommandCallback(),
       );
     }
-    return Text('AutoInstrumentNavigationBasicDeferScenarioScreen');
+    return const Text('AutoInstrumentNavigationBasicDeferScenarioScreen');
   }
 
   void setStage(int stage) {

--- a/features/fixture_resources/lib/scenarios/auto_instrument_navigation_basic_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_navigation_basic_scenario.dart
@@ -1,7 +1,5 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 
@@ -15,11 +13,11 @@ class AutoInstrumentNavigationBasicScenario extends Scenario {
 
   @override
   Widget? createWidget() {
-    return Text('AutoInstrumentNavigationBasicScenario');
+    return const Text('AutoInstrumentNavigationBasicScenario');
   }
 
   @override
   RouteSettings? routeSettings() {
-    return RouteSettings(name: 'basic_navigation_scenario');
+    return const RouteSettings(name: 'basic_navigation_scenario');
   }
 }

--- a/features/fixture_resources/lib/scenarios/auto_instrument_navigation_complex_defer_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_navigation_complex_defer_scenario.dart
@@ -1,6 +1,5 @@
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:flutter/material.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 

--- a/features/fixture_resources/lib/scenarios/auto_instrument_navigation_nested_navigation_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_navigation_nested_navigation_scenario.dart
@@ -1,7 +1,6 @@
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 
 import 'package:flutter/material.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 

--- a/features/fixture_resources/lib/scenarios/auto_instrument_navigation_push_and_pop_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_navigation_push_and_pop_scenario.dart
@@ -1,6 +1,4 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:flutter/material.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 
@@ -62,8 +60,8 @@ class AutoInstrumentNavigationPushAndPopScenarioScreenState
   Widget build(BuildContext context) {
     return GestureDetector(
       child: Container(
-        child: Text('AutoInstrumentNavigationPushAndPopScenarioScreen'),
         color: Colors.white,
+        child: Text('AutoInstrumentNavigationPushAndPopScenarioScreen'),
       ),
       onTap: () => widget.runCommandCallback(),
     );

--- a/features/fixture_resources/lib/scenarios/auto_instrument_navigation_with_view_load_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/auto_instrument_navigation_with_view_load_scenario.dart
@@ -1,6 +1,5 @@
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:flutter/material.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 

--- a/features/fixture_resources/lib/scenarios/correlation_null_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/correlation_null_scenario.dart
@@ -1,6 +1,5 @@
 import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 

--- a/features/fixture_resources/lib/scenarios/correlation_simple_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/correlation_simple_scenario.dart
@@ -1,6 +1,5 @@
 import 'package:bugsnag_flutter/bugsnag_flutter.dart';
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
-import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
 

--- a/features/fixture_resources/lib/scenarios/custom_app_version_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_app_version_scenario.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'scenario.dart';
 
 class CustomAppVersionScenario extends Scenario {

--- a/features/fixture_resources/lib/scenarios/custom_enabled_release_stage_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_enabled_release_stage_scenario.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'scenario.dart';
 
 class CustomEnabledReleaseStageScenario extends Scenario {

--- a/features/fixture_resources/lib/scenarios/custom_release_stage_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_release_stage_scenario.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'scenario.dart';
 
 class CustomReleaseStageScenario extends Scenario {

--- a/features/fixture_resources/lib/scenarios/custom_service_name_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_service_name_scenario.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'scenario.dart';
 
 class CustomServiceNameScenario extends Scenario {

--- a/features/fixture_resources/lib/scenarios/custom_span_attributes_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_span_attributes_scenario.dart
@@ -1,0 +1,43 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+
+import 'scenario.dart';
+
+class CustomSpanAttributesScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await startBugsnag(onSpanEndCallbacks: [
+      _setAttributesAndThrow,
+      _discardUnwantedSpan,
+      _setAttributes,
+    ]);
+    setMaxBatchSize(1);
+    doSimpleSpan('CustomSpanAttributesScenarioDiscaredSpan');
+    final span =
+        bugsnag_performance.startSpan('CustomSpanAttributesScenarioSpan');
+    span.setAttribute('customAttribute1', 42);
+    span.setAttribute('customAttribute2', 'Test');
+    span.setAttribute('customAttribute3', 1);
+    span.end();
+    span.setAttribute('customAttribute5', 'T');
+  }
+
+  Future<bool> _setAttributesAndThrow(BugsnagPerformanceSpan span) async {
+    span.setAttribute('customAttribute1', 'C');
+    throw Exception('');
+  }
+
+  Future<bool> _discardUnwantedSpan(BugsnagPerformanceSpan span) async {
+    if (span.name == 'CustomSpanAttributesScenarioDiscaredSpan') {
+      return false;
+    }
+    return true;
+  }
+
+  Future<bool> _setAttributes(BugsnagPerformanceSpan span) async {
+    span.setAttribute('customAttribute3', 2);
+    span.setAttribute('customAttribute3', 3);
+    span.setAttribute('customAttribute2', null);
+    span.setAttribute('customAttribute4', 42.0);
+    return true;
+  }
+}

--- a/features/fixture_resources/lib/scenarios/custom_span_attributes_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_span_attributes_scenario.dart
@@ -18,7 +18,7 @@ class CustomSpanAttributesScenario extends Scenario {
     span.setAttribute('customAttribute2', 'Test');
     span.setAttribute('customAttribute3', 1);
     span.end();
-    span.setAttribute('customAttribute5', 'T');
+    span.setAttribute('customAttribute6', 'T');
   }
 
   Future<bool> _setAttributesAndThrow(BugsnagPerformanceSpan span) async {
@@ -38,6 +38,12 @@ class CustomSpanAttributesScenario extends Scenario {
     span.setAttribute('customAttribute3', 3);
     span.setAttribute('customAttribute2', null);
     span.setAttribute('customAttribute4', 42.0);
+    span.setAttribute('customAttribute5', [
+      'customString',
+      42,
+      true,
+      43.0,
+    ]);
     return true;
   }
 }

--- a/features/fixture_resources/lib/scenarios/custom_span_attributes_with_limits_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_span_attributes_with_limits_scenario.dart
@@ -1,0 +1,36 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+
+import 'scenario.dart';
+
+class CustomSpanAttributesWithLimitsScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await startBugsnag(
+        attributeCountLimit: 8,
+        attributeStringValueLimit: 20,
+        attributeArrayLengthLimit: 6,
+        onSpanEndCallbacks: [
+          _setAttributes,
+        ]);
+    setMaxBatchSize(1);
+    final span = bugsnag_performance
+        .startSpan('CustomSpanAttributesWithLimitsScenarioSpan');
+    const tooLongKey =
+        'trberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc';
+    span.setAttribute('customAttribute1', 42);
+    span.setAttribute(tooLongKey, 'Test');
+    span.setAttribute('customAttribute2', 1);
+    span.setAttribute('customAttribute3', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    span.setAttribute(
+        'customAttribute4', 'VeryLongStringAttributeValueThatExceedsTheLimit');
+    span.setAttribute('customAttribute5', 42.0);
+    span.setAttribute('customAttribute6', 'Dropped');
+    span.end();
+  }
+
+  Future<bool> _setAttributes(BugsnagPerformanceSpan span) async {
+    span.setAttribute('customAttribute7', 'Droppedtoo');
+    span.setAttribute('customAttribute2', 'NotDropped');
+    return true;
+  }
+}

--- a/features/fixture_resources/lib/scenarios/custom_span_attributes_with_limits_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/custom_span_attributes_with_limits_scenario.dart
@@ -15,8 +15,7 @@ class CustomSpanAttributesWithLimitsScenario extends Scenario {
     setMaxBatchSize(1);
     final span = bugsnag_performance
         .startSpan('CustomSpanAttributesWithLimitsScenarioSpan');
-    const tooLongKey =
-        'trberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc';
+    final tooLongKey = 'a' * 129;
     span.setAttribute('customAttribute1', 42);
     span.setAttribute(tooLongKey, 'Test');
     span.setAttribute('customAttribute2', 1);

--- a/features/fixture_resources/lib/scenarios/dio_callback_cancel_span.dart
+++ b/features/fixture_resources/lib/scenarios/dio_callback_cancel_span.dart
@@ -1,5 +1,4 @@
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
-import 'package:bugsnag_http_client/bugsnag_http_client.dart';
 import 'package:dio/io.dart';
 import '../main.dart';
 import 'scenario.dart';

--- a/features/fixture_resources/lib/scenarios/dio_callback_edit_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/dio_callback_edit_scenario.dart
@@ -1,5 +1,4 @@
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
-import 'package:bugsnag_http_client/bugsnag_http_client.dart';
 import 'package:dio/io.dart';
 import '../main.dart';
 import 'scenario.dart';

--- a/features/fixture_resources/lib/scenarios/disable_custom_release_stage_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/disable_custom_release_stage_scenario.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'scenario.dart';
 
 class DisableCustomReleaseStageScenario extends Scenario {

--- a/features/fixture_resources/lib/scenarios/http_client_trace_propagation_urls_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/http_client_trace_propagation_urls_scenario.dart
@@ -11,7 +11,7 @@ class HttpClientTracePropagationUrlsScenario extends Scenario {
     http.addSubscriber(bugsnag_performance.networkInstrumentation);
     http.get(
         Uri.parse('${FixtureConfig.MAZE_HOST.toString()}/reflect?dontsend'));
-    await Future.delayed(Duration(seconds: 1));
+    await Future.delayed(const Duration(seconds: 1));
     http.get(Uri.parse('${FixtureConfig.MAZE_HOST.toString()}/reflect?dosend'));
   }
 }

--- a/features/fixture_resources/lib/scenarios/initial_p_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/initial_p_scenario.dart
@@ -1,10 +1,7 @@
-import 'dart:convert';
-
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
-import 'package:http/http.dart' as http;
 
 class InitialPScenario extends Scenario {
   @override
@@ -15,7 +12,7 @@ class InitialPScenario extends Scenario {
     bugsnag_performance.setExtraConfig("probabilityValueExpireTime", 25000);
     bugsnag_performance.start(
         apiKey: '12312312312312312312312312312312',
-        endpoint: Uri.parse(FixtureConfig.MAZE_HOST.toString() + '/traces'));
+        endpoint: Uri.parse('${FixtureConfig.MAZE_HOST}/traces'));
     setMaxBatchSize(1);
     doSimpleSpan('First');
   }

--- a/features/fixture_resources/lib/scenarios/manual_span_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/manual_span_scenario.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'scenario.dart';
 
 class ManualSpanScenario extends Scenario {

--- a/features/fixture_resources/lib/scenarios/max_batch_age_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/max_batch_age_scenario.dart
@@ -1,4 +1,3 @@
-import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'scenario.dart';
 
 class MaxBatchAgeScenario extends Scenario {

--- a/features/fixture_resources/lib/scenarios/probability_expiry_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/probability_expiry_scenario.dart
@@ -1,10 +1,7 @@
-import 'dart:convert';
-
 import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 import 'package:mazerunner/main.dart';
 
 import 'scenario.dart';
-import 'package:http/http.dart' as http;
 
 class ProbabilityExpiryScenario extends Scenario {
   @override
@@ -14,9 +11,9 @@ class ProbabilityExpiryScenario extends Scenario {
     bugsnag_performance.setExtraConfig("probabilityValueExpireTime", 100);
     bugsnag_performance.start(
         apiKey: '12312312312312312312312312312312',
-        endpoint: Uri.parse(FixtureConfig.MAZE_HOST.toString() + '/traces'));
+        endpoint: Uri.parse('${FixtureConfig.MAZE_HOST}/traces'));
     setMaxBatchSize(1);
-    await Future.delayed(Duration(milliseconds: 500));
+    await Future.delayed(const Duration(milliseconds: 500));
     doSimpleSpan('myspan');
   }
 }

--- a/features/fixture_resources/lib/scenarios/scenario.dart
+++ b/features/fixture_resources/lib/scenarios/scenario.dart
@@ -49,6 +49,7 @@ abstract class Scenario {
     String? appVersion,
     bool shouldUseNotifier = false,
     double? samplingProbability,
+    List<Future<bool> Function(BugsnagPerformanceSpan)>? onSpanEndCallbacks,
   }) async {
     bugsnag_performance.setExtraConfig("instrumentAppStart", false);
     bugsnag_performance.setExtraConfig("probabilityValueExpireTime", 1000);
@@ -61,6 +62,7 @@ abstract class Scenario {
       serviceName: serviceName,
       appVersion: appVersion,
       samplingProbability: samplingProbability,
+      onSpanEndCallbacks: onSpanEndCallbacks,
     );
     if (shouldUseNotifier && endpointConfiguration != null) {
       await bugsnag.start(

--- a/features/fixture_resources/lib/scenarios/scenario.dart
+++ b/features/fixture_resources/lib/scenarios/scenario.dart
@@ -49,6 +49,9 @@ abstract class Scenario {
     String? appVersion,
     bool shouldUseNotifier = false,
     double? samplingProbability,
+    int? attributeCountLimit,
+    int? attributeStringValueLimit,
+    int? attributeArrayLengthLimit,
     List<Future<bool> Function(BugsnagPerformanceSpan)>? onSpanEndCallbacks,
   }) async {
     bugsnag_performance.setExtraConfig("instrumentAppStart", false);
@@ -62,6 +65,9 @@ abstract class Scenario {
       serviceName: serviceName,
       appVersion: appVersion,
       samplingProbability: samplingProbability,
+      attributeCountLimit: attributeCountLimit,
+      attributeStringValueLimit: attributeStringValueLimit,
+      attributeArrayLengthLimit: attributeArrayLengthLimit,
       onSpanEndCallbacks: onSpanEndCallbacks,
     );
     if (shouldUseNotifier && endpointConfiguration != null) {

--- a/features/fixture_resources/lib/scenarios/scenarios.dart
+++ b/features/fixture_resources/lib/scenarios/scenarios.dart
@@ -9,6 +9,7 @@ import 'package:mazerunner/scenarios/auto_instrument_view_load_nested_scenario.d
 import 'package:mazerunner/scenarios/correlation_null_scenario.dart';
 import 'package:mazerunner/scenarios/correlation_simple_scenario.dart';
 import 'package:mazerunner/scenarios/custom_service_name_scenario.dart';
+import 'package:mazerunner/scenarios/custom_span_attributes_scenario.dart';
 import 'package:mazerunner/scenarios/dart_io_traceparent_scenario.dart';
 import 'package:mazerunner/scenarios/fixed_sampling_probability_one_scenario.dart';
 import 'package:mazerunner/scenarios/fixed_sampling_probability_zero_scenario.dart';
@@ -127,4 +128,6 @@ final List<ScenarioInfo<Scenario>> scenarios = [
   ScenarioInfo('FixedSamplingProbabilityZeroScenario',
       () => FixedSamplingProbabilityZeroScenario()),
   ScenarioInfo('CustomServiceNameScenario', () => CustomServiceNameScenario()),
+  ScenarioInfo(
+      'CustomSpanAttributesScenario', () => CustomSpanAttributesScenario())
 ];

--- a/features/fixture_resources/lib/scenarios/scenarios.dart
+++ b/features/fixture_resources/lib/scenarios/scenarios.dart
@@ -18,6 +18,7 @@ import 'package:mazerunner/scenarios/http_client_traceparent_scenario.dart';
 
 import 'auto_instrument_app_starts_scenario.dart';
 import 'auto_instrument_navigation_with_view_load_scenario.dart';
+import 'custom_span_attributes_with_limits_scenario.dart';
 import 'dio_callback_cancel_span.dart';
 import 'dio_callback_edit_scenario.dart';
 import 'initial_p_scenario.dart';
@@ -129,5 +130,7 @@ final List<ScenarioInfo<Scenario>> scenarios = [
       () => FixedSamplingProbabilityZeroScenario()),
   ScenarioInfo('CustomServiceNameScenario', () => CustomServiceNameScenario()),
   ScenarioInfo(
-      'CustomSpanAttributesScenario', () => CustomSpanAttributesScenario())
+      'CustomSpanAttributesScenario', () => CustomSpanAttributesScenario()),
+  ScenarioInfo('CustomSpanAttributesWithLimitsScenario',
+      () => CustomSpanAttributesWithLimitsScenario())
 ];

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -51,7 +51,7 @@ Feature: Manual Spans
     * the span named "no-parent" exists
     * the span named "no-parent" has no parent
 
-Scenario: Manual Navigation Span
+  Scenario: Manual Navigation Span
     When I run "ManualNavigationSpanScenario"
     And I wait for 1 span
     Then the trace "Content-Type" header equals "application/json"
@@ -68,5 +68,25 @@ Scenario: Manual Navigation Span
     * every span string attribute "bugsnag.navigation.triggered_by" equals "manual"
     * every span string attribute "bugsnag.navigation.previous_route" equals "navigationScenarioPreviousRoute"
     * a span double attribute "bugsnag.sampling.p" equals 1.0
+
+  Scenario: Custom attributes
+    When I run "CustomSpanAttributesScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * every span field "name" equals "CustomSpanAttributesScenarioSpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span string attribute "bugsnag.span.category" equals "custom"
+    * a span double attribute "bugsnag.sampling.p" equals 1.0
+    * a span string attribute "customAttribute1" equals "C"
+    * every span string attribute "customAttribute2" does not exist
+    * a span integer attribute "customAttribute3" equals 3
+    * a span double attribute "customAttribute4" equals 42.0
+    * every span string attribute "customAttribute5" does not exist
 
 

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -111,7 +111,7 @@ Feature: Manual Spans
     * every span string attribute "bugsnag.span.category" equals "custom"
     * a span double attribute "bugsnag.sampling.p" equals 1.0
     * a span integer attribute "customAttribute1" equals 42
-    * every span string attribute "trberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc" does not exist
+    * every span string attribute "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" does not exist
     * a span string attribute "customAttribute2" equals "NotDropped"
     * a span array attribute "customAttribute3" contains 6 items
     * a span array attribute "customAttribute3" contains the integer value 1 at index 0

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -87,6 +87,11 @@ Feature: Manual Spans
     * every span string attribute "customAttribute2" does not exist
     * a span integer attribute "customAttribute3" equals 3
     * a span double attribute "customAttribute4" equals 42.0
-    * every span string attribute "customAttribute5" does not exist
+    * a span array attribute "customAttribute5" contains 4 items
+    * a span array attribute "customAttribute5" contains the string value "customString" at index 0
+    * a span array attribute "customAttribute5" contains the integer value 42 at index 1
+    * a span array attribute "customAttribute5" contains the value true at index 2
+    * a span array attribute "customAttribute5" contains the double value 43.0 at index 3
+    * every span string attribute "customAttribute6" does not exist
 
 

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -80,6 +80,7 @@ Feature: Manual Spans
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "droppedAttributesCount" does not exist
     * every span bool attribute "bugsnag.span.first_class" is true
     * every span string attribute "bugsnag.span.category" equals "custom"
     * a span double attribute "bugsnag.sampling.p" equals 1.0
@@ -93,5 +94,35 @@ Feature: Manual Spans
     * a span array attribute "customAttribute5" contains the value true at index 2
     * a span array attribute "customAttribute5" contains the double value 43.0 at index 3
     * every span string attribute "customAttribute6" does not exist
+
+  Scenario: Custom attributes - limits
+    When I run "CustomSpanAttributesWithLimitsScenario"
+    And I wait for 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * every span field "name" equals "CustomSpanAttributesWithLimitsScenarioSpan"
+    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
+    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
+    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
+    * every span field "droppedAttributesCount" equals 3
+    * every span bool attribute "bugsnag.span.first_class" is true
+    * every span string attribute "bugsnag.span.category" equals "custom"
+    * a span double attribute "bugsnag.sampling.p" equals 1.0
+    * a span integer attribute "customAttribute1" equals 42
+    * every span string attribute "trberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc" does not exist
+    * a span string attribute "customAttribute2" equals "NotDropped"
+    * a span array attribute "customAttribute3" contains 6 items
+    * a span array attribute "customAttribute3" contains the integer value 1 at index 0
+    * a span array attribute "customAttribute3" contains the integer value 2 at index 1
+    * a span array attribute "customAttribute3" contains the integer value 3 at index 2
+    * a span array attribute "customAttribute3" contains the integer value 4 at index 3
+    * a span array attribute "customAttribute3" contains the integer value 5 at index 4
+    * a span array attribute "customAttribute3" contains the integer value 6 at index 5
+    * a span string attribute "customAttribute4" equals "VeryLongStringAttrib*** 27 CHARS TRUNCATED"
+    * a span double attribute "customAttribute5" equals 42.0
+    * every span string attribute "customAttribute6" does not exist
+    * every span string attribute "customAttribute7" does not exist
 
 

--- a/features/steps/flutter_steps.rb
+++ b/features/steps/flutter_steps.rb
@@ -123,6 +123,13 @@ Then('a span integer attribute {string} is greater than {int}') do |attribute, e
   Maze.check.false(attribute_values.empty?)
 end
 
+Then('a span integer attribute {string} equals {int}') do |attribute, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('intValue') } }.compact
+  attribute_values = selected_attributes.map { |a| a['value']['intValue'].to_i == expected }
+  Maze.check.false(attribute_values.empty?)
+end
+
 Then('a span double attribute {string} equals {float}') do |attribute, value|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('doubleValue') } }.compact

--- a/features/steps/flutter_steps.rb
+++ b/features/steps/flutter_steps.rb
@@ -209,6 +209,17 @@ Then('no span named {string} exists') do |span_name|
   Maze.check.true(spans_with_name.length() == 0);
 end
 
+Then('every span field {string} does not exist') do |key|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  spans.map { |span| Maze.check.nil span[key] }
+end
+
+Then('every span field {string} equals {int}') do |key, expected|
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_keys = spans.map { |span| span[key] == expected }
+  Maze.check.not_includes selected_keys, false
+end
+
 Then('a span array attribute {string} contains the string value {string} at index {int}') do |attribute, expected, index|
   value = get_array_value_at_index(attribute, index, 'stringValue')
   Maze.check.true(value == expected)

--- a/features/steps/flutter_steps.rb
+++ b/features/steps/flutter_steps.rb
@@ -208,3 +208,56 @@ Then('no span named {string} exists') do |span_name|
 
   Maze.check.true(spans_with_name.length() == 0);
 end
+
+Then('a span array attribute {string} contains the string value {string} at index {int}') do |attribute, expected, index|
+  value = get_array_value_at_index(attribute, index, 'stringValue')
+  Maze.check.true(value == expected)
+end
+
+Then('a span array attribute {string} contains the integer value {int} at index {int}') do |attribute, expected, index|
+  value = get_array_value_at_index(attribute, index, 'intValue')
+  Maze.check.true(value.to_i == expected)
+end
+
+Then('a span array attribute {string} contains the double value {float} at index {int}') do |attribute, expected, index|
+  value = get_array_value_at_index(attribute, index, 'doubleValue')
+  Maze.check.true(value == expected)
+end
+
+Then('a span array attribute {string} contains the value true at index {int}') do |attribute, index|
+  value = get_array_value_at_index(attribute, index, 'boolValue')
+  Maze.check.true(value == true)
+end
+
+Then('a span array attribute {string} contains the value false at index {int}') do |attribute, index|
+  value = get_array_value_at_index(attribute, index, 'boolValue')
+  Maze.check.true(value == false)
+end
+
+Then('a span array attribute {string} contains {int} items') do |attribute, length|
+  array = get_array_attribute_contents(attribute)
+  Maze.check.true(array.length() == length)
+end
+
+Then('a span array attribute {string} is empty') do |attribute|
+  array_contents = get_array_attribute_contents(attribute)
+  Maze.check.true(array_contents.empty?)
+end
+
+def get_array_value_at_index(attribute, index, type)
+  array = get_array_attribute_contents(attribute)
+  Maze.check.true(array.length() > index)
+  value = array[index]
+  Maze.check.true(value.has_key?(type))
+  return value[type]
+end
+
+def get_array_attribute_contents(attribute)
+  spans = spans_from_request_list(Maze::Server.list_for('traces'))
+  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) &&
+                                                                         a['value'].has_key?('arrayValue') &&
+                                                                         a['value']['arrayValue'].has_key?('values') } }.compact
+  array_attributes = selected_attributes.map { |a| a['value']['arrayValue']['values'] }
+  Maze.check.false(array_attributes.empty?)
+  return array_attributes[0]
+end

--- a/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
+++ b/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
@@ -44,6 +44,7 @@ class BugsnagPerformance {
     String? serviceName,
     String? appVersion,
     double? samplingProbability,
+    List<Future<bool> Function(BugsnagPerformanceSpan)>? onSpanEndCallbacks,
   }) {
     _validateApiKey(apiKey);
     return _client.start(
@@ -56,6 +57,7 @@ class BugsnagPerformance {
       serviceName: serviceName,
       appVersion: appVersion,
       samplingProbability: samplingProbability,
+      onSpanEndCallbacks: onSpanEndCallbacks,
     );
   }
 

--- a/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
+++ b/packages/bugsnag_flutter_performance/lib/bugsnag_flutter_performance.dart
@@ -44,6 +44,9 @@ class BugsnagPerformance {
     String? serviceName,
     String? appVersion,
     double? samplingProbability,
+    int? attributeCountLimit,
+    int? attributeStringValueLimit,
+    int? attributeArrayLengthLimit,
     List<Future<bool> Function(BugsnagPerformanceSpan)>? onSpanEndCallbacks,
   }) {
     _validateApiKey(apiKey);
@@ -57,6 +60,9 @@ class BugsnagPerformance {
       serviceName: serviceName,
       appVersion: appVersion,
       samplingProbability: samplingProbability,
+      attributeCountLimit: attributeCountLimit,
+      attributeStringValueLimit: attributeStringValueLimit,
+      attributeArrayLengthLimit: attributeArrayLengthLimit,
       onSpanEndCallbacks: onSpanEndCallbacks,
     );
   }

--- a/packages/bugsnag_flutter_performance/lib/src/client.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/client.dart
@@ -577,22 +577,22 @@ class BugsnagPerformanceClientImpl implements BugsnagPerformanceClient {
     if (span is BugsnagPerformanceSpanImpl) {
       span.makeMutable(true);
     }
-    for (OnSpanEndCallback callback in _onSpanEndCallbacks) {
-      try {
-        if (!(await callback(span))) {
-          if (span is BugsnagPerformanceSpanImpl) {
-            span.makeMutable(false);
+    try {
+      for (OnSpanEndCallback callback in _onSpanEndCallbacks) {
+        try {
+          if (!(await callback(span))) {
+            return false;
           }
-          return false;
-        }
-      } catch (e) {
-        if (kDebugMode) {
-          print('onSpanEnd callback threw exception: $e');
+        } catch (e) {
+          if (kDebugMode) {
+            print('onSpanEnd callback threw exception: $e');
+          }
         }
       }
-    }
-    if (span is BugsnagPerformanceSpanImpl) {
-      span.makeMutable(false);
+    } finally {
+      if (span is BugsnagPerformanceSpanImpl) {
+        span.makeMutable(false);
+      }
     }
     return true;
   }

--- a/packages/bugsnag_flutter_performance/lib/src/client.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/client.dart
@@ -93,6 +93,7 @@ class BugsnagPerformanceClientImpl implements BugsnagPerformanceClient {
   RetryQueue? _retryQueue;
   Sampler? _sampler;
   DateTime? _lastSamplingProbabilityRefreshDate;
+  List<OnSpanEndCallback> _onSpanEndCallbacks = [];
   late final PackageBuilder _packageBuilder;
   late final BugsnagClock _clock;
   late final BugsnagLifecycleListener? _lifecycleListener;
@@ -104,7 +105,6 @@ class BugsnagPerformanceClientImpl implements BugsnagPerformanceClient {
   final Map<String, BugsnagPerformanceSpan> _networkSpans = {};
   BugsnagNetworkRequestInfo? Function(BugsnagNetworkRequestInfo)?
       _networkRequestCallback;
-  late final List<OnSpanEndCallback> _onSpanEndCallbacks;
   final Map<SpanId, BugsnagPerformanceSpan> _potentiallyOpenSpans = {};
   final spanContextStackExpando = Expando<BugsnagPerformanceSpanContextStack>();
 

--- a/packages/bugsnag_flutter_performance/lib/src/configuration.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/configuration.dart
@@ -8,6 +8,9 @@ class BugsnagPerformanceConfiguration {
     this.serviceName,
     this.appVersion,
     this.samplingProbability,
+    required this.attributeCountLimit,
+    required this.attributeStringValueLimit,
+    required this.attributeArrayLengthLimit,
   });
   String? apiKey;
   Uri? endpoint;
@@ -24,6 +27,9 @@ class BugsnagPerformanceConfiguration {
   String? serviceName;
   String? appVersion;
   double? samplingProbability;
+  int attributeCountLimit;
+  int attributeStringValueLimit;
+  int attributeArrayLengthLimit;
 
   bool releaseStageEnabled() {
     return releaseStage == null ||

--- a/packages/bugsnag_flutter_performance/lib/src/span.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span.dart
@@ -4,6 +4,7 @@ import 'package:bugsnag_flutter_performance/src/span_attributes.dart';
 import 'package:bugsnag_flutter_performance/src/span_context.dart';
 import 'package:bugsnag_flutter_performance/src/util/clock.dart';
 import 'package:bugsnag_flutter_performance/src/util/random.dart';
+import 'package:flutter/foundation.dart';
 
 typedef TraceId = BigInt;
 typedef SpanId = BigInt;
@@ -45,6 +46,7 @@ class BugsnagPerformanceSpanImpl
     this.onCanceled = onCanceled ?? _onCanceled;
     this.attributes = attributes ?? BugsnagPerformanceSpanAttributes();
   }
+  @override
   final String name;
   @override
   late final TraceId traceId;
@@ -89,9 +91,15 @@ class BugsnagPerformanceSpanImpl
     onEnded(this);
   }
 
+  @override
   void setAttribute(String key, dynamic value) {
     if (_isMutable) {
       attributes.setAttribute(key, value);
+    } else {
+      if (kDebugMode) {
+        print(
+            'Span attribute "$key" in span $name was dropped as the span is no longer open');
+      }
     }
   }
 

--- a/packages/bugsnag_flutter_performance/lib/src/span.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span.dart
@@ -23,6 +23,8 @@ abstract class BugsnagPerformanceSpan implements BugsnagPerformanceSpanContext {
   });
   String get encodedTraceId;
   String get encodedSpanId;
+  String get name;
+  void setAttribute(String key, dynamic value);
   dynamic toJson();
 }
 
@@ -54,6 +56,7 @@ class BugsnagPerformanceSpanImpl
   late final BugsnagPerformanceSpanAttributes attributes;
   DateTime? endTime;
   var isSampled = false;
+  var _isMutable = true;
   late final void Function(BugsnagPerformanceSpan) onEnded;
   late final void Function(BugsnagPerformanceSpan) onCanceled;
   late final BugsnagClock clock;
@@ -70,6 +73,7 @@ class BugsnagPerformanceSpanImpl
       return;
     }
     this.endTime = endTime ?? clock.now();
+    makeMutable(false);
     if (cancelled) {
       onCanceled(this);
       return;
@@ -83,6 +87,12 @@ class BugsnagPerformanceSpanImpl
       attributes.responseContentLength = responseContentLength;
     }
     onEnded(this);
+  }
+
+  void setAttribute(String key, dynamic value) {
+    if (_isMutable) {
+      attributes.setAttribute(key, value);
+    }
   }
 
   BugsnagPerformanceSpanImpl.fromJson(Map<String, dynamic> json,
@@ -140,6 +150,10 @@ class BugsnagPerformanceSpanImpl
 
   @override
   String get encodedSpanId => _encodeSpanId(spanId);
+
+  void makeMutable(bool mutable) {
+    _isMutable = mutable;
+  }
 }
 
 String _encodeSpanId(SpanId spanId) {

--- a/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
@@ -93,7 +93,7 @@ class BugsnagPerformanceSpanAttributes {
   factory BugsnagPerformanceSpanAttributes.fromJson(
       List<Map<String, dynamic>> json) {
     final attributes = <String, dynamic>{};
-    for (var element in json) {
+    for (final element in json) {
       final key = element['key'];
       dynamic value = _decodeAttributeValue(element['value']);
 
@@ -117,7 +117,7 @@ class BugsnagPerformanceSpanAttributes {
       final arrayValue = valueMap['arrayValue'];
       if (arrayValue is Map<String, List> && arrayValue.containsKey('values')) {
         List result = [];
-        for (var element in arrayValue['values']!) {
+        for (final element in arrayValue['values']!) {
           dynamic decodedValue = _decodeAttributeValue(element);
           if (decodedValue != null) {
             result.add(decodedValue);
@@ -208,7 +208,10 @@ class BugsnagPerformanceSpanAttributesEncoder {
     if (value is List) {
       return _encodeListAttributeValue(key, value);
     }
-    return value;
+    if (value is double || value is bool) {
+      return value;
+    }
+    return value.toString();
   }
 
   dynamic _encodeListAttributeValue(
@@ -216,7 +219,7 @@ class BugsnagPerformanceSpanAttributesEncoder {
     List listAttribute,
   ) {
     List result = [];
-    for (var (index, value) in listAttribute.indexed) {
+    for (final (index, value) in listAttribute.indexed) {
       final runtimeType = value.runtimeType;
       if (_typeMap[runtimeType] != null) {
         result.add(_encodeAttributeValue(key, value));

--- a/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
@@ -52,22 +52,13 @@ class BugsnagPerformanceSpanAttributes {
   }
 
   dynamic toJson() {
-    const typeMap = {
-      bool: 'boolValue',
-      double: 'doubleValue',
-      int: 'intValue',
-      String: 'stringValue',
-    };
-
     return attributes.entries.map((entry) {
       final key = entry.key;
       final value = entry.value;
-      String valueType = typeMap[value.runtimeType] ?? 'stringValue';
-      dynamic formattedValue = value is int ? value.toString() : value;
 
       return {
         'key': key,
-        'value': {valueType: formattedValue},
+        'value': _encodeAttributeValue(value),
       };
     }).toList();
   }
@@ -77,23 +68,81 @@ class BugsnagPerformanceSpanAttributes {
     final attributes = <String, dynamic>{};
     for (var element in json) {
       final key = element['key'];
-      final Map<String, dynamic> valueMap = element['value'];
-      dynamic value;
-
-      if (valueMap.containsKey('stringValue')) {
-        value = valueMap['stringValue'];
-      } else if (valueMap.containsKey('boolValue')) {
-        value = valueMap['boolValue'];
-      } else if (valueMap.containsKey('doubleValue')) {
-        value = double.tryParse(valueMap['doubleValue'].toString());
-      } else if (valueMap.containsKey('intValue')) {
-        value = int.tryParse(valueMap['intValue']);
-      }
+      dynamic value = _decodeAttributeValue(element['value']);
 
       if (key != null && value != null) {
         attributes[key] = value;
       }
     }
     return BugsnagPerformanceSpanAttributes(additionalAttributes: attributes);
+  }
+
+  static const _typeMap = {
+    bool: 'boolValue',
+    double: 'doubleValue',
+    int: 'intValue',
+    String: 'stringValue'
+  };
+
+  static const _listTypeMap = {
+    List<bool>: 'arrayValue',
+    List<double>: 'arrayValue',
+    List<int>: 'arrayValue',
+    List<String>: 'arrayValue',
+    List<Object>: 'arrayValue'
+  };
+
+  static dynamic _decodeAttributeValue(Map<String, dynamic> valueMap) {
+    if (valueMap.containsKey('stringValue')) {
+      return valueMap['stringValue'];
+    } else if (valueMap.containsKey('boolValue')) {
+      return valueMap['boolValue'];
+    } else if (valueMap.containsKey('doubleValue')) {
+      return double.tryParse(valueMap['doubleValue'].toString());
+    } else if (valueMap.containsKey('intValue')) {
+      return int.tryParse(valueMap['intValue']);
+    } else if (valueMap.containsKey('arrayValue')) {
+      final arrayValue = valueMap['arrayValue'];
+      if (arrayValue is Map<String, List> && arrayValue.containsKey('values')) {
+        List result = [];
+        for (var element in arrayValue['values']!) {
+          dynamic decodedValue = _decodeAttributeValue(element);
+          if (decodedValue != null) {
+            result.add(decodedValue);
+          }
+        }
+        return result;
+      }
+    }
+    return null;
+  }
+
+  dynamic _encodeAttributeValue(dynamic value) {
+    final runtimeType = value.runtimeType;
+    String valueType =
+        _typeMap[runtimeType] ?? _listTypeMap[runtimeType] ?? 'stringValue';
+    dynamic formattedValue = _formattedValue(value);
+    return {valueType: formattedValue};
+  }
+
+  dynamic _formattedValue(dynamic value) {
+    if (value is int) {
+      return value.toString();
+    }
+    if (value is List) {
+      return _encodeListAttributeValue(value);
+    }
+    return value;
+  }
+
+  dynamic _encodeListAttributeValue(List listAttribute) {
+    List result = [];
+    for (var value in listAttribute) {
+      final runtimeType = value.runtimeType;
+      if (_typeMap[runtimeType] != null) {
+        result.add(_encodeAttributeValue(value));
+      }
+    }
+    return {'values': result};
   }
 }

--- a/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
@@ -1,3 +1,17 @@
+import 'package:bugsnag_flutter_performance/src/configuration.dart';
+import 'package:bugsnag_flutter_performance/src/span_attributes_limits.dart';
+import 'package:flutter/foundation.dart';
+
+class BugsnagPerformanceSpanAttributesEncodingResult {
+  final dynamic jsonValue;
+  final int droppedAttributesCount;
+
+  BugsnagPerformanceSpanAttributesEncodingResult({
+    required this.jsonValue,
+    required this.droppedAttributesCount,
+  });
+}
+
 class BugsnagPerformanceSpanAttributes {
   final Map<String, dynamic> attributes = {};
 
@@ -51,16 +65,29 @@ class BugsnagPerformanceSpanAttributes {
     return attributes['bugsnag.sampling.p'];
   }
 
-  dynamic toJson() {
-    return attributes.entries.map((entry) {
-      final key = entry.key;
-      final value = entry.value;
+  int get count => attributes.length;
 
-      return {
-        'key': key,
-        'value': _encodeAttributeValue(value),
-      };
-    }).toList();
+  bool hasAttribute(String key) {
+    return attributes.containsKey(key);
+  }
+
+  BugsnagPerformanceSpanAttributesEncodingResult toJson({
+    BugsnagPerformanceConfiguration? config,
+  }) {
+    final attributeKeyLengthLimit = SpanAttributesLimits.limitValue(
+        type: SpanAttributesLimitType.keyLengthLimit);
+    final attributeStringValueLimit = config?.attributeStringValueLimit ??
+        SpanAttributesLimits.limitValue(
+            type: SpanAttributesLimitType.stringValueLimit);
+    final attributeArrayLengthLimit = config?.attributeArrayLengthLimit ??
+        SpanAttributesLimits.limitValue(
+            type: SpanAttributesLimitType.arrayLengthLimit);
+
+    return BugsnagPerformanceSpanAttributesEncoder(
+      attributeKeyLengthLimit: attributeKeyLengthLimit,
+      attributeStringValueLimit: attributeStringValueLimit,
+      attributeArrayLengthLimit: attributeArrayLengthLimit,
+    ).toJson(attributes);
   }
 
   factory BugsnagPerformanceSpanAttributes.fromJson(
@@ -76,21 +103,6 @@ class BugsnagPerformanceSpanAttributes {
     }
     return BugsnagPerformanceSpanAttributes(additionalAttributes: attributes);
   }
-
-  static const _typeMap = {
-    bool: 'boolValue',
-    double: 'doubleValue',
-    int: 'intValue',
-    String: 'stringValue'
-  };
-
-  static const _listTypeMap = {
-    List<bool>: 'arrayValue',
-    List<double>: 'arrayValue',
-    List<int>: 'arrayValue',
-    List<String>: 'arrayValue',
-    List<Object>: 'arrayValue'
-  };
 
   static dynamic _decodeAttributeValue(Map<String, dynamic> valueMap) {
     if (valueMap.containsKey('stringValue')) {
@@ -116,32 +128,111 @@ class BugsnagPerformanceSpanAttributes {
     }
     return null;
   }
+}
 
-  dynamic _encodeAttributeValue(dynamic value) {
+class BugsnagPerformanceSpanAttributesEncoder {
+  int attributeKeyLengthLimit;
+  int attributeStringValueLimit;
+  int attributeArrayLengthLimit;
+
+  BugsnagPerformanceSpanAttributesEncoder({
+    required this.attributeKeyLengthLimit,
+    required this.attributeStringValueLimit,
+    required this.attributeArrayLengthLimit,
+  });
+
+  static const _typeMap = {
+    bool: 'boolValue',
+    double: 'doubleValue',
+    int: 'intValue',
+    String: 'stringValue'
+  };
+
+  static const _listTypeMap = {
+    List<bool>: 'arrayValue',
+    List<double>: 'arrayValue',
+    List<int>: 'arrayValue',
+    List<String>: 'arrayValue',
+    List<Object>: 'arrayValue'
+  };
+
+  BugsnagPerformanceSpanAttributesEncodingResult toJson(
+    Map<String, dynamic> attributes,
+  ) {
+    final validKeys =
+        attributes.keys.where((key) => key.length <= attributeKeyLengthLimit);
+
+    final jsonValue = validKeys.map((key) {
+      final value = attributes[key];
+
+      return {
+        'key': key,
+        'value': _encodeAttributeValue(key, value),
+      };
+    }).toList();
+
+    return BugsnagPerformanceSpanAttributesEncodingResult(
+      jsonValue: jsonValue,
+      droppedAttributesCount: attributes.length - validKeys.length,
+    );
+  }
+
+  dynamic _encodeAttributeValue(
+    String key,
+    dynamic value,
+  ) {
     final runtimeType = value.runtimeType;
     String valueType =
         _typeMap[runtimeType] ?? _listTypeMap[runtimeType] ?? 'stringValue';
-    dynamic formattedValue = _formattedValue(value);
+    dynamic formattedValue = _formattedValue(key, value);
     return {valueType: formattedValue};
   }
 
-  dynamic _formattedValue(dynamic value) {
+  dynamic _formattedValue(
+    String key,
+    dynamic value,
+  ) {
+    if (value is String) {
+      if (value.length > attributeStringValueLimit) {
+        if (kDebugMode) {
+          print(
+              'The value for span attribute "$key" was truncated as it exceeds the $attributeStringValueLimit attribute limit set by AttributeStringValueLimit');
+        }
+        return '${value.substring(0, attributeStringValueLimit)}*** ${value.length - attributeStringValueLimit} CHARS TRUNCATED';
+      }
+      return value;
+    }
     if (value is int) {
       return value.toString();
     }
     if (value is List) {
-      return _encodeListAttributeValue(value);
+      return _encodeListAttributeValue(key, value);
     }
     return value;
   }
 
-  dynamic _encodeListAttributeValue(List listAttribute) {
+  dynamic _encodeListAttributeValue(
+    String key,
+    List listAttribute,
+  ) {
     List result = [];
-    for (var value in listAttribute) {
+    for (var (index, value) in listAttribute.indexed) {
       final runtimeType = value.runtimeType;
       if (_typeMap[runtimeType] != null) {
-        result.add(_encodeAttributeValue(value));
+        result.add(_encodeAttributeValue(key, value));
+      } else {
+        if (kDebugMode) {
+          print(
+              'The element at index $index for span attribute "$key" was excluded as its type is not valid.');
+        }
       }
+    }
+    if (result.length > attributeArrayLengthLimit) {
+      if (kDebugMode) {
+        print(
+            'The value for span attribute "$key" was truncated as it exceeds the $attributeArrayLengthLimit attribute limit set by AttributeArrayLengthLimit');
+      }
+      result = result.sublist(0, attributeArrayLengthLimit).toList();
     }
     return {'values': result};
   }

--- a/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
@@ -26,6 +26,8 @@ class BugsnagPerformanceSpanAttributes {
   void setAttribute(String key, dynamic value) {
     if (value != null) {
       attributes[key] = value;
+    } else {
+      attributes.remove(key);
     }
   }
 

--- a/packages/bugsnag_flutter_performance/lib/src/span_attributes_limits.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span_attributes_limits.dart
@@ -1,0 +1,77 @@
+enum SpanAttributesLimitType {
+  keyLengthLimit,
+  stringValueLimit,
+  arrayLengthLimit,
+  attributeCountLimit,
+}
+
+class SpanAttributesLimits {
+  static const _attributeKeyLengthLimit = 128;
+
+  static const _defaultAttributeStringValueLimit = 1024;
+  static const _minAttributeStringValueLimit = 1;
+  static const _maxAttributeStringValueLimit = 10000;
+
+  static const _defaultAttributeArrayLengthLimit = 1000;
+  static const _minAttributeArrayLengthLimit = 1;
+  static const _maxAttributeArrayLengthLimit = 10000;
+
+  static const _defaultAttributeCountLimit = 128;
+  static const _minAttributeCountLimit = 1;
+  static const _maxAttributeCountLimit = 1000;
+
+  static int limitValue({
+    required SpanAttributesLimitType type,
+    int? providedValue,
+  }) {
+    if (providedValue == null) {
+      return _defaultValue(type);
+    }
+    if (providedValue < _minValue(type)) {
+      return _defaultValue(type);
+    }
+    if (providedValue > _maxValue(type)) {
+      return _maxValue(type);
+    }
+    return providedValue;
+  }
+
+  static int _defaultValue(SpanAttributesLimitType type) {
+    switch (type) {
+      case SpanAttributesLimitType.keyLengthLimit:
+        return _attributeKeyLengthLimit;
+      case SpanAttributesLimitType.stringValueLimit:
+        return _defaultAttributeStringValueLimit;
+      case SpanAttributesLimitType.arrayLengthLimit:
+        return _defaultAttributeArrayLengthLimit;
+      case SpanAttributesLimitType.attributeCountLimit:
+        return _defaultAttributeCountLimit;
+    }
+  }
+
+  static int _minValue(SpanAttributesLimitType type) {
+    switch (type) {
+      case SpanAttributesLimitType.keyLengthLimit:
+        return _attributeKeyLengthLimit;
+      case SpanAttributesLimitType.stringValueLimit:
+        return _minAttributeStringValueLimit;
+      case SpanAttributesLimitType.arrayLengthLimit:
+        return _minAttributeArrayLengthLimit;
+      case SpanAttributesLimitType.attributeCountLimit:
+        return _minAttributeCountLimit;
+    }
+  }
+
+  static int _maxValue(SpanAttributesLimitType type) {
+    switch (type) {
+      case SpanAttributesLimitType.keyLengthLimit:
+        return _attributeKeyLengthLimit;
+      case SpanAttributesLimitType.stringValueLimit:
+        return _maxAttributeStringValueLimit;
+      case SpanAttributesLimitType.arrayLengthLimit:
+        return _maxAttributeArrayLengthLimit;
+      case SpanAttributesLimitType.attributeCountLimit:
+        return _maxAttributeCountLimit;
+    }
+  }
+}

--- a/packages/bugsnag_flutter_performance/lib/src/uploader/package_builder.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/uploader/package_builder.dart
@@ -61,7 +61,7 @@ class PackageBuilderImpl implements PackageBuilder {
   Future<List<int>> _buildPayload({
     required List<BugsnagPerformanceSpan> spans,
   }) async {
-    final jsonList = spans.map((span) => span.toJson()).toList();
+    final jsonList = spans.map((span) => span.toJson(config: _config)).toList();
     final jsonRequest = {
       'resourceSpans': [
         {

--- a/packages/bugsnag_flutter_performance/test/src/span_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/span_test.dart
@@ -127,6 +127,19 @@ void main() {
               'key': 'custom',
               'value': {'stringValue': 'value'}
             },
+            {
+              'key': 'customArray',
+              'value': {
+                'arrayValue': {
+                  'values': [
+                    {'stringValue': 'testValue'},
+                    {'intValue': '1'},
+                    {'doubleValue': 4.2},
+                    {'boolValue': true},
+                  ]
+                }
+              }
+            },
           ],
         };
         final span = BugsnagPerformanceSpanImpl.fromJson(json);
@@ -147,6 +160,14 @@ void main() {
             span.parentSpanId,
             equals(
                 BigInt.tryParse(json['parentSpanId'] as String, radix: 16)!));
+        expect(
+            span.attributes.attributes['customArray'],
+            equals([
+              'testValue',
+              1,
+              4.2,
+              true,
+            ]));
       });
 
       test('should decode a running span', () {
@@ -185,6 +206,14 @@ void main() {
           parentSpanId: randomSpanId(),
         );
         span.clock = BugsnagClockImpl.instance;
+        span.setAttribute('customString', 'testValue');
+        span.setAttribute('customInt', 2);
+        span.setAttribute('list', [
+          42,
+          43.0,
+          'testString',
+          false,
+        ]);
         span.end();
         final json = span.toJson();
         expect(json['name'], equals(span.name));
@@ -199,6 +228,37 @@ void main() {
             equals(span.spanId.toRadixString(16).padLeft(16, '0')));
         expect(json['parentSpanId'],
             equals(span.parentSpanId!.toRadixString(16).padLeft(16, '0')));
+        final attributes = json['attributes'] as List<Map<String, dynamic>>;
+        expect(
+          attributes[0],
+          equals({
+            'key': 'customString',
+            'value': {'stringValue': 'testValue'},
+          }),
+        );
+        expect(
+          attributes[1],
+          equals({
+            'key': 'customInt',
+            'value': {'intValue': '2'},
+          }),
+        );
+        expect(
+          attributes[2],
+          equals({
+            'key': 'list',
+            'value': {
+              'arrayValue': {
+                'values': [
+                  {'intValue': '42'},
+                  {'doubleValue': 43.0},
+                  {'stringValue': 'testString'},
+                  {'boolValue': false},
+                ],
+              }
+            },
+          }),
+        );
       });
 
       test('should encode a running span', () {

--- a/packages/bugsnag_flutter_performance/test/src/span_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/span_test.dart
@@ -1,3 +1,4 @@
+import 'package:bugsnag_flutter_performance/src/configuration.dart';
 import 'package:bugsnag_flutter_performance/src/extensions/bugsnag_lifecycle_listener.dart';
 import 'package:bugsnag_flutter_performance/src/extensions/date_time.dart';
 import 'package:bugsnag_flutter_performance/src/extensions/int.dart';
@@ -208,12 +209,7 @@ void main() {
         span.clock = BugsnagClockImpl.instance;
         span.setAttribute('customString', 'testValue');
         span.setAttribute('customInt', 2);
-        span.setAttribute('list', [
-          42,
-          43.0,
-          'testString',
-          false,
-        ]);
+        span.setAttribute('list', [42, 43.0, 'testString', false, true, 1]);
         span.end();
         final json = span.toJson();
         expect(json['name'], equals(span.name));
@@ -254,11 +250,14 @@ void main() {
                   {'doubleValue': 43.0},
                   {'stringValue': 'testString'},
                   {'boolValue': false},
+                  {'boolValue': true},
+                  {'intValue': '1'},
                 ],
               }
             },
           }),
         );
+        expect(json['droppedAttributesCount'], isNull);
       });
 
       test('should encode a running span', () {
@@ -272,6 +271,117 @@ void main() {
         expect(int.parse(json['startTimeUnixNano']),
             equals(span.startTime.nanosecondsSinceEpoch));
         expect(json['endTimeUnixNano'], isNull);
+        expect(json['droppedAttributesCount'], isNull);
+      });
+
+      test('should drop attributes with too long keys', () {
+        const tooLongKey =
+            'trberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc';
+        const tooLongKey2 =
+            'Atrbesfsdffrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc';
+        final span = BugsnagPerformanceSpanImpl(
+            name: 'Test name',
+            startTime: DateTime.fromMillisecondsSinceEpoch(
+                millisecondsSinceEpoch,
+                isUtc: true));
+        span.clock = BugsnagClockImpl.instance;
+        span.setAttribute(tooLongKey, 'test');
+        span.setAttribute(tooLongKey2, 'test2');
+        span.setAttribute('TestBool', false);
+        span.end();
+        final json = span.toJson();
+        final attributes = json['attributes'] as List<Map<String, dynamic>>;
+        expect(attributes.length, equals(1));
+        expect(
+            attributes[0],
+            equals({
+              'key': 'TestBool',
+              'value': {'boolValue': false},
+            }));
+        expect(json['droppedAttributesCount'], equals(2));
+      });
+
+      test(
+          'should include attributes added over limit along with those with too long keys in droppedAttributesCount',
+          () {
+        const tooLongKey =
+            'trberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc';
+        const tooLongKey2 =
+            'Atrbesfsdffrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwctrberwfqfrefwefrgrewfrfwefwftvrvwreqwcwc';
+        final span = BugsnagPerformanceSpanImpl(
+          name: 'Test name',
+          startTime: DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch,
+              isUtc: true),
+          attributeCountLimit: 3,
+        );
+        span.clock = BugsnagClockImpl.instance;
+        span.setAttribute('TestInt', 1);
+        span.setAttribute(tooLongKey, 'test');
+        span.setAttribute(tooLongKey2, 'test2');
+        span.setAttribute('TestBool', false);
+        span.setAttribute('TestBool2', true);
+        span.setAttribute('TestInt', 2);
+        span.setAttribute('TestInt', 3);
+        span.end();
+        final json = span.toJson();
+        final attributes = json['attributes'] as List<Map<String, dynamic>>;
+        expect(attributes.length, equals(1));
+        expect(
+            attributes[0],
+            equals({
+              'key': 'TestInt',
+              'value': {'intValue': '3'},
+            }));
+        expect(json['droppedAttributesCount'], equals(4));
+      });
+
+      test('should truncate strings and arrays that go over the limits', () {
+        final span = BugsnagPerformanceSpanImpl(
+          name: 'Test name',
+          startTime: DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch,
+              isUtc: true),
+        );
+        span.clock = BugsnagClockImpl.instance;
+        span.setAttribute('TestString', 'test');
+        span.setAttribute('LongTestString', 'This is a very long string');
+        span.setAttribute('TestArray', [true, '2', 3.0, 4, '5', 6.0, 7]);
+        span.end();
+        final config = BugsnagPerformanceConfiguration(
+          attributeCountLimit: 100,
+          attributeStringValueLimit: 10,
+          attributeArrayLengthLimit: 4,
+        );
+        final json = span.toJson(config: config);
+        final attributes = json['attributes'] as List<Map<String, dynamic>>;
+        expect(attributes.length, equals(3));
+        expect(
+            attributes[0],
+            equals({
+              'key': 'TestString',
+              'value': {'stringValue': 'test'},
+            }));
+        expect(
+            attributes[1],
+            equals({
+              'key': 'LongTestString',
+              'value': {'stringValue': 'This is a *** 16 CHARS TRUNCATED'},
+            }));
+        expect(
+            attributes[2],
+            equals({
+              'key': 'TestArray',
+              'value': {
+                'arrayValue': {
+                  'values': [
+                    {'boolValue': true},
+                    {'stringValue': '2'},
+                    {'doubleValue': 3.0},
+                    {'intValue': '4'}
+                  ],
+                }
+              },
+            }));
+        expect(json['droppedAttributesCount'], isNull);
       });
     });
   });

--- a/packages/bugsnag_flutter_performance/test/src/uploader/span_batch_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/uploader/span_batch_test.dart
@@ -1,5 +1,6 @@
 import 'package:bugsnag_flutter_performance/src/configuration.dart';
 import 'package:bugsnag_flutter_performance/src/span.dart';
+import 'package:bugsnag_flutter_performance/src/span_attributes_limits.dart';
 import 'package:bugsnag_flutter_performance/src/uploader/span_batch.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -32,7 +33,14 @@ void main() {
 
       setUp(() {
         batch.configure(
-          BugsnagPerformanceConfiguration()..maxBatchSize = batchSize,
+          BugsnagPerformanceConfiguration(
+            attributeCountLimit: SpanAttributesLimits.limitValue(
+                type: SpanAttributesLimitType.attributeCountLimit),
+            attributeStringValueLimit: SpanAttributesLimits.limitValue(
+                type: SpanAttributesLimitType.stringValueLimit),
+            attributeArrayLengthLimit: SpanAttributesLimits.limitValue(
+                type: SpanAttributesLimitType.arrayLengthLimit),
+          )..maxBatchSize = batchSize,
         );
       });
 


### PR DESCRIPTION
## Goal

Allow users to add custom span attributes.

## Design

- Whenever the real limits values are not available, the default values are used as a fallback
- The count of dropped attributes due to number of attributes exceeding AttributeCountLimit is incremented with every attempt to add an attribute over limit
- The count of dropped attributes that are dropped due to the name length exceeding the limit is calculated when the span is converted to json. The two counts are then added and set as the total droppedAttributesCount for a span. Thanks of that, calling toJson() multiple times on the same span will yield the same result every time.

## Changeset

- Added setAttribute method to BugsnagPerformanceSpan
- Added onSpanEnd callbacks
- Ensured span immutability after the span was closed
- Added Lists of primitives to supported attribute types
- Implemented non-configurable attribute name length limit and configurable limits: AttributeStringValueLimit, AttributeArrayLengthLimit, AttributeCountLimit

## Testing

E2E Tests