### PR TITLE
update device_info_plus version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Changes
+
+* Relaxed the device_info_plus dep to allow any version between 9.1.0 and 12.0.0 [100](https://github.com/bugsnag/bugsnag-flutter-performance/pull/100)
+
 ## 1.4.0 (2025-01-17)
 
 ### Changes

--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  device_info_plus: ^9.1.0
+  device_info_plus: ">=9.1.0"
   package_info_plus: ^8.0.0
   path_provider: ^2.0.2
   uuid: ^4.0.0

--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  device_info_plus: ">=9.1.0"
+  device_info_plus: '>=9.1.0 <12.0.0'
   package_info_plus: ^8.0.0
   path_provider: ^2.0.2
   uuid: ^4.0.0


### PR DESCRIPTION
## Goal

The flutter plugin was tied to v9 of the device_info_plus package.
This PR updates it to allow any version between 9.1.0 and 12.0.0 (not including 12).

## Testing

Covered by a full CI run