### PR TITLE
pin flutter native version in e2e fixture

### DIFF
--- a/features/scripts/generate_fixture.sh
+++ b/features/scripts/generate_fixture.sh
@@ -53,8 +53,7 @@ $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" path_provider
 
 $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" http
 
-$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" native_flutter_proxy --version 0.1.15
-
+$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "native_flutter_proxy:0.1.15"
 #$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "bugsnag_http_client:{'path':'$HTTP_WRAPPER_PACKAGE_PATH'}"
 #$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "bugsnag_flutter_dart_io_http_client:{'path':'$DART_IO_WRAPPER_PACKAGE_PATH'}"
 

--- a/features/scripts/generate_fixture.sh
+++ b/features/scripts/generate_fixture.sh
@@ -53,7 +53,7 @@ $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" path_provider
 
 $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" http
 
-$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" native_flutter_proxy
+$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" native_flutter_proxy --version 0.1.15
 
 #$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "bugsnag_http_client:{'path':'$HTTP_WRAPPER_PACKAGE_PATH'}"
 #$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "bugsnag_flutter_dart_io_http_client:{'path':'$DART_IO_WRAPPER_PACKAGE_PATH'}"


### PR DESCRIPTION
## Goal

A new version of the flutter native package breaks our current fixture.
Work should be done in future to ensure our fixture works with the new version.
Until then this PR pins the version to a working version.