### PR TITLE
Use macOS 15 build servers in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: macos-14
+  queue: macos-15
 
 steps:
 


### PR DESCRIPTION
## Goal

Use macOS 15 build servers in CI.

## Testing

Covered by CI.