### PR TITLE
Use macOS 15 for iOS fixture builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,8 +23,6 @@ steps:
   - label: Build iOS Test Fixture
     key: "ios-fixture-3-10-0"
     timeout_in_minutes: 20
-    agents:
-      queue: macos-14
     env:
       FLUTTER_VERSION: "3.19.0"
     commands:


### PR DESCRIPTION
## Goal

Move iOS fixture build to macos-15.

## Testing

Covered by CI.