### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Changes
+
+* Set default endpoints based on API key [#107](https://github.com/bugsnag/bugsnag-flutter-performance/pull/107)
+
 ## 1.4.1 (2025-04-07)
 
 ### Changes

--- a/packages/bugsnag_flutter_performance/lib/src/client.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/client.dart
@@ -30,8 +30,14 @@ import 'span.dart';
 
 typedef OnSpanEndCallback = Future<bool> Function(BugsnagPerformanceSpan);
 
-String _defaultEndpoint(String? apiKey) =>
-    'https://${apiKey != null ? '$apiKey.' : ''}otlp.bugsnag.com/v1/traces';
+String _defaultEndpoint(String? apiKey) {
+  // InsightHub keys always begin with 00000…
+  final bool isHubKey = apiKey != null && apiKey.startsWith('00000');
+  final String host =
+  isHubKey ? 'otlp.insighthub.smartbear.com' : 'otlp.bugsnag.com';
+  final String subdomain = apiKey != null ? '$apiKey.' : '';
+  return 'https://$subdomain$host/v1/traces';
+}
 
 abstract class BugsnagPerformanceClient {
   Future<void> start({

--- a/packages/bugsnag_flutter_performance/test/src/endpoint_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/endpoint_test.dart
@@ -9,7 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 class _MockRetryQueue implements RetryQueue {
   @override
-  Future<void> enqueue({required Map<String, String> headers, required Uint8List body}) async {}
+  Future<void> enqueue(
+      {required Map<String, String> headers, required Uint8List body}) async {}
   @override
   Future<void> flush() async {}
 }
@@ -20,27 +21,27 @@ class _MockRetryQueueBuilder implements RetryQueueBuilder {
 }
 
 class _MockLifecycleListener implements BugsnagLifecycleListener {
-  void Function()? _handler;
   @override
   void startObserving({void Function()? onAppBackgrounded}) {
-    _handler = onAppBackgrounded;
   }
 }
 
 void main() {
-
-  const validKey  = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
-  const hubKey    = '00000deadbeefdeadbeefdeadbeef00';
+  const validKey = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+  const hubKey = '00000deadbeefdeadbeefdeadbeef00';
   final explicitEndpoint = Uri.parse('https://example.com/otel');
-  final defaultBugsnag   = Uri.parse('https://otlp.bugsnag.com/v1/traces');
-  final defaultWithKey   = Uri.parse('https://$validKey.otlp.bugsnag.com/v1/traces');
-  final defaultHubHost   = Uri.parse('https://$hubKey.otlp.insighthub.smartbear.com/v1/traces');
+  final defaultBugsnag = Uri.parse('https://otlp.bugsnag.com/v1/traces');
+  final defaultWithKey =
+      Uri.parse('https://$validKey.otlp.bugsnag.com/v1/traces');
+  final defaultHubHost =
+      Uri.parse('https://$hubKey.otlp.insighthub.smartbear.com/v1/traces');
 
   BugsnagPerformanceClientImpl freshClient(_MockLifecycleListener listener) {
     final c = BugsnagPerformanceClientImpl(lifecycleListener: listener);
     c.retryQueueBuilder = _MockRetryQueueBuilder();
     return c;
   }
+
   BugsnagClockImpl.ensureInitialized();
 
   group('Endpoint selection', () {
@@ -62,7 +63,8 @@ void main() {
       expect(client.configuration!.endpoint, explicitEndpoint);
     });
 
-    test('prefixes hub subdomain when InsightHub key (00000…) supplied', () async {
+    test('prefixes hub subdomain when InsightHub key (00000…) supplied',
+        () async {
       final client = freshClient(_MockLifecycleListener());
       await client.start(apiKey: hubKey);
       expect(client.configuration!.endpoint, defaultHubHost);

--- a/packages/bugsnag_flutter_performance/test/src/endpoint_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/endpoint_test.dart
@@ -1,0 +1,71 @@
+import 'dart:typed_data';
+import 'package:bugsnag_flutter_performance/src/client.dart';
+import 'package:bugsnag_flutter_performance/src/extensions/bugsnag_lifecycle_listener.dart';
+import 'package:bugsnag_flutter_performance/src/uploader/retry_queue.dart';
+import 'package:bugsnag_flutter_performance/src/uploader/retry_queue_builder.dart';
+import 'package:bugsnag_flutter_performance/src/uploader/uploader.dart';
+import 'package:bugsnag_flutter_performance/src/util/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _MockRetryQueue implements RetryQueue {
+  @override
+  Future<void> enqueue({required Map<String, String> headers, required Uint8List body}) async {}
+  @override
+  Future<void> flush() async {}
+}
+
+class _MockRetryQueueBuilder implements RetryQueueBuilder {
+  @override
+  RetryQueue build(Uploader uploader) => _MockRetryQueue();
+}
+
+class _MockLifecycleListener implements BugsnagLifecycleListener {
+  void Function()? _handler;
+  @override
+  void startObserving({void Function()? onAppBackgrounded}) {
+    _handler = onAppBackgrounded;
+  }
+}
+
+void main() {
+
+  const validKey  = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+  const hubKey    = '00000deadbeefdeadbeefdeadbeef00';
+  final explicitEndpoint = Uri.parse('https://example.com/otel');
+  final defaultBugsnag   = Uri.parse('https://otlp.bugsnag.com/v1/traces');
+  final defaultWithKey   = Uri.parse('https://$validKey.otlp.bugsnag.com/v1/traces');
+  final defaultHubHost   = Uri.parse('https://$hubKey.otlp.insighthub.smartbear.com/v1/traces');
+
+  BugsnagPerformanceClientImpl freshClient(_MockLifecycleListener listener) {
+    final c = BugsnagPerformanceClientImpl(lifecycleListener: listener);
+    c.retryQueueBuilder = _MockRetryQueueBuilder();
+    return c;
+  }
+  BugsnagClockImpl.ensureInitialized();
+
+  group('Endpoint selection', () {
+    test('defaults to Bugsnag OTLP when no apiKey supplied', () async {
+      final client = freshClient(_MockLifecycleListener());
+      await client.start();
+      expect(client.configuration!.endpoint, defaultBugsnag);
+    });
+
+    test('prefixes apiKey subdomain when apiKey supplied', () async {
+      final client = freshClient(_MockLifecycleListener());
+      await client.start(apiKey: validKey);
+      expect(client.configuration!.endpoint, defaultWithKey);
+    });
+
+    test('uses caller-supplied endpoint unchanged', () async {
+      final client = freshClient(_MockLifecycleListener());
+      await client.start(apiKey: validKey, endpoint: explicitEndpoint);
+      expect(client.configuration!.endpoint, explicitEndpoint);
+    });
+
+    test('prefixes hub subdomain when InsightHub key (00000…) supplied', () async {
+      final client = freshClient(_MockLifecycleListener());
+      await client.start(apiKey: hubKey);
+      expect(client.configuration!.endpoint, defaultHubHost);
+    });
+  });
+}


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no endpoint is configured, payloads should be sent to `*.otlp.insighthub.smartbear.com` if the API key starts with `00000`.

## Testing

Added new unit tests