### PR TITLE
shorter batch timeout in dev builds and example app update

### DIFF
--- a/example/bugsnag_performance_example/android/app/build.gradle
+++ b/example/bugsnag_performance_example/android/app/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -21,22 +27,18 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
     namespace "com.example.bugsnag_performance_example"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {

--- a/example/bugsnag_performance_example/android/build.gradle
+++ b/example/bugsnag_performance_example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/bugsnag_performance_example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/bugsnag_performance_example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/example/bugsnag_performance_example/android/settings.gradle
+++ b/example/bugsnag_performance_example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+}
+
+include ":app"

--- a/example/bugsnag_performance_example/pubspec.yaml
+++ b/example/bugsnag_performance_example/pubspec.yaml
@@ -30,8 +30,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  bugsnag_http_client:
-    path: ../../packages/bugsnag-flutter-http-client
+  bugsnag_http_client: ^2.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/bugsnag_flutter_performance/lib/src/configuration.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/configuration.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 class BugsnagPerformanceConfiguration {
   BugsnagPerformanceConfiguration({
     this.apiKey,
@@ -15,7 +17,7 @@ class BugsnagPerformanceConfiguration {
   String? apiKey;
   Uri? endpoint;
   int maxBatchSize = 100;
-  int maxBatchAge = 60 * 1000; // milliseconds
+  int maxBatchAge = kDebugMode ? 5 * 1000 : 60 * 1000; // 5 seconds for debug, 60 seconds for release
   int probabilityRequestsPause = 30000;
   int probabilityValueExpireTime = 24 * 3600 * 1000;
   bool instrumentAppStart = true;


### PR DESCRIPTION
## Goal

When running a dev build the batch timeout will now be 5 seconds as opposed to 60 in production. 
This makes testing and debugging easier for developers.

The example app has also been updated so that it compiles and runs without issues in an up to date dev env.

