### PR TITLE
Wait for spans by name

### DIFF
--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -8,7 +8,6 @@ Feature: Automatic instrumentation spans
     And I wait to receive at least 4 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:4"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[AppStart/FlutterInit]"
     * a span field "name" equals "[AppStartPhase/pre runApp()]"
     * a span field "name" equals "[AppStartPhase/runApp()]"
@@ -33,7 +32,6 @@ Feature: Automatic instrumentation spans
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[Navigation]basic_navigation_scenario"
     * a span string attribute "bugsnag.span.category" equals "navigation"
     * a span string attribute "bugsnag.navigation.route" equals "basic_navigation_scenario"
@@ -54,7 +52,6 @@ Feature: Automatic instrumentation spans
     Then I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[Navigation]basic_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "basic_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
@@ -80,7 +77,6 @@ Feature: Automatic instrumentation spans
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[Navigation]complex_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "complex_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
@@ -121,7 +117,6 @@ Feature: Automatic instrumentation spans
     Then I invoke "step4"
     And I wait to receive at least 4 spans
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[Navigation]nested_scenario_child_navigator/nested_scenario_child_route_3"
     * a span string attribute "bugsnag.navigation.route" equals "nested_scenario_child_route_3"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "replace"
@@ -146,7 +141,6 @@ Feature: Automatic instrumentation spans
     Then I wait to receive at least 2 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[Navigation]push_and_pop_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "push_and_pop_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "pop"
@@ -164,7 +158,6 @@ Feature: Automatic instrumentation spans
     And I wait for 3 seconds
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:3"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * a span string attribute "bugsnag.span.category" equals "view_load_phase"
@@ -186,7 +179,6 @@ Feature: Automatic instrumentation spans
     And I wait to receive at least 2 spans
     And I wait for 3 seconds
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/building"
     * a span string attribute "bugsnag.phase" equals "building"
     * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/appearing"
@@ -214,7 +206,6 @@ Feature: Automatic instrumentation spans
     And I wait to receive at least 4 spans
     And I wait for 3 seconds
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/building"
     * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/building"
     * a span string attribute "bugsnag.phase" equals "building"
@@ -263,7 +254,6 @@ Feature: Automatic instrumentation spans
     And I wait to receive at least 5 spans
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * a span field "name" equals "[Navigation]navigation_view_load_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "navigation_view_load_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"

--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -5,13 +5,12 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentAppStartsScenario
     Given I run "AutoInstrumentAppStartsScenario"
-    And I wait to receive at least 4 spans
+    And I wait to receive a span named "[AppStart/FlutterInit]"
+    * I wait to receive a span named "[AppStartPhase/pre runApp()]"
+    * I wait to receive a span named "[AppStartPhase/runApp()]"
+    * I wait to receive a span named "[AppStartPhase/UI init]"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:4"
-    * a span field "name" equals "[AppStart/FlutterInit]"
-    * a span field "name" equals "[AppStartPhase/pre runApp()]"
-    * a span field "name" equals "[AppStartPhase/runApp()]"
-    * a span field "name" equals "[AppStartPhase/UI init]"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
@@ -29,10 +28,9 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentNavigationBasicScenario
     Given I run "AutoInstrumentNavigationBasicScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "[Navigation]basic_navigation_scenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * a span field "name" equals "[Navigation]basic_navigation_scenario"
     * a span string attribute "bugsnag.span.category" equals "navigation"
     * a span string attribute "bugsnag.navigation.route" equals "basic_navigation_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
@@ -49,10 +47,9 @@ Feature: Automatic instrumentation spans
     And I wait for 5 seconds
     * no span named "[Navigation]basic_defer_navigation_scenario" exists
     And I invoke "step2"
-    Then I wait to receive at least 1 span
+    Then I wait to receive a span named "[Navigation]basic_defer_navigation_scenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * a span field "name" equals "[Navigation]basic_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "basic_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
@@ -74,10 +71,9 @@ Feature: Automatic instrumentation spans
     And I wait for 3 seconds
     * no span named "[Navigation]complex_defer_navigation_scenario" exists
     Then I invoke "step4"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "[Navigation]complex_defer_navigation_scenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * a span field "name" equals "[Navigation]complex_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "complex_defer_navigation_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
@@ -93,31 +89,29 @@ Feature: Automatic instrumentation spans
     And I wait for 3 seconds
     * no span named "[Navigation]nested_defer_navigation_scenario_parent" exists
     Then I invoke "step2"
-    And I wait to receive at least 2 spans
-    * a span field "name" equals "[Navigation]nested_defer_navigation_scenario_parent"
+    And I wait to receive a span named "[Navigation]nested_defer_navigation_scenario_parent"
+    * I wait to receive a span named "[Navigation]nested_scenario_child_navigator/nested_scenario_child_route_initial"
+
     * a span string attribute "bugsnag.navigation.route" equals "nested_defer_navigation_scenario_parent"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
 
-    * a span field "name" equals "[Navigation]nested_scenario_child_navigator/nested_scenario_child_route_initial"
     * a span string attribute "bugsnag.navigation.route" equals "nested_scenario_child_route_initial"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
     * a span string attribute "bugsnag.navigation.navigator" equals "nested_scenario_child_navigator"
     Then I invoke "step3"
-    And I wait to receive at least 3 spans
-    * a span field "name" equals "[Navigation]nested_scenario_child_navigator/nested_scenario_child_route_2"
+    And I wait to receive a span named "[Navigation]nested_scenario_child_navigator/nested_scenario_child_route_2"
     * a span string attribute "bugsnag.navigation.route" equals "nested_scenario_child_route_2"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "nested_scenario_child_route_initial"
     * a span string attribute "bugsnag.navigation.navigator" equals "nested_scenario_child_navigator"
     Then I invoke "step4"
-    And I wait to receive at least 4 spans
+    And I wait to receive a span named "[Navigation]nested_scenario_child_navigator/nested_scenario_child_route_3"
     Then the trace "Content-Type" header equals "application/json"
-    * a span field "name" equals "[Navigation]nested_scenario_child_navigator/nested_scenario_child_route_3"
     * a span string attribute "bugsnag.navigation.route" equals "nested_scenario_child_route_3"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "replace"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
@@ -131,18 +125,16 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentNavigationPushAndPopScenario
     Given I run "AutoInstrumentNavigationPushAndPopScenario"
-    And I wait to receive at least 1 span
-    * a span field "name" equals "[Navigation]push_and_pop_scenario"
+    And I wait to receive a span named "[Navigation]push_and_pop_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "push_and_pop_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
     And I invoke "step2"
-    Then I wait to receive at least 2 spans
-    Then the trace "Content-Type" header equals "application/json"
+    Then I wait to receive a span named "[Navigation]/"
+    * the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * a span field "name" equals "[Navigation]push_and_pop_scenario"
-    * a span string attribute "bugsnag.navigation.route" equals "push_and_pop_scenario"
+    * a span string attribute "bugsnag.navigation.route" equals "/"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "pop"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "push_and_pop_scenario"
@@ -154,16 +146,14 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentViewLoadBasicScenario
     Given I run "AutoInstrumentViewLoadBasicScenario"
-    And I wait to receive at least 3 spans
-    And I wait for 3 seconds
+    And I wait to receive a span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/building"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/appearing"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:3"
-    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * a span string attribute "bugsnag.span.category" equals "view_load_phase"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/building"
     * a span string attribute "bugsnag.phase" equals "building"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/appearing"
     * a span string attribute "bugsnag.phase" equals "appearing"
     * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/loading content" exists
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
@@ -176,21 +166,18 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentViewLoadBasicDeferScenario
     Given I run "AutoInstrumentViewLoadBasicDeferScenario"
-    And I wait to receive at least 2 spans
-    And I wait for 3 seconds
+    And I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/building"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/appearing"
     Then the trace "Content-Type" header equals "application/json"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/building"
     * a span string attribute "bugsnag.phase" equals "building"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/appearing"
     * a span string attribute "bugsnag.phase" equals "appearing"
     * a span string attribute "bugsnag.span.category" equals "view_load_phase"
     * no span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget" exists
     * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading content" exists
     And I invoke "step2"
-    And I wait to receive at least 4 spans
-    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget"
+    And I wait to receive a span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading content"
     * a span string attribute "bugsnag.phase" equals "loading content"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -203,14 +190,12 @@ Feature: Automatic instrumentation spans
 
   Scenario: AutoInstrumentViewLoadNestedScenario
     Given I run "AutoInstrumentViewLoadNestedScenario"
-    And I wait to receive at least 4 spans
-    And I wait for 3 seconds
+    And I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/building"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/building"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/appearing"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/appearing"
     Then the trace "Content-Type" header equals "application/json"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/building"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/building"
     * a span string attribute "bugsnag.phase" equals "building"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/appearing"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/appearing"
     * a span string attribute "bugsnag.phase" equals "appearing"
     * a span string attribute "bugsnag.span.category" equals "view_load_phase"
     * no span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget" exists
@@ -218,12 +203,11 @@ Feature: Automatic instrumentation spans
     * no span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget" exists
     * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading content" exists
     And I invoke "step2"
-    And I wait to receive at least 8 spans
-    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget"
-    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget"
+    And I wait to receive a span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget"
+    * I wait to receive a span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/loading content"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/loading content"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading content"
     * a span string attribute "bugsnag.phase" equals "loading content"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -251,22 +235,21 @@ Feature: Automatic instrumentation spans
     * no span named "[Navigation]navigation_view_load_scenario" exists
     * no span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" exists
     Then I invoke "step4"
-    And I wait to receive at least 5 spans
+    And I wait to receive a span named "[Navigation]navigation_view_load_scenario"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/building"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/appearing"
+    * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/loading content"
+    * I wait to receive a span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * a span field "name" equals "[Navigation]navigation_view_load_scenario"
     * a span string attribute "bugsnag.navigation.route" equals "navigation_view_load_scenario"
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/building"
     * a span string attribute "bugsnag.phase" equals "building"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/appearing"
     * a span string attribute "bugsnag.phase" equals "appearing"
-    * a span field "name" equals "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/loading content"
     * a span string attribute "bugsnag.phase" equals "loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load_phase"
-    * a span field "name" equals "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -7,11 +7,10 @@ Feature: Configuration overrides
     Given I set the sampling probability for the next traces to "0"
     And I enter unmanaged traces mode
     And I run "FixedSamplingProbabilityOneScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "FixedSamplingProbabilitySpan1"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * every span field "name" equals "FixedSamplingProbabilitySpan1"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
@@ -19,9 +18,8 @@ Feature: Configuration overrides
     Then I discard the oldest trace
     Then I set the sampling probability for the next traces to "0"
     And I invoke "step2"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "FixedSamplingProbabilitySpan2"
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * every span field "name" equals "FixedSamplingProbabilitySpan2"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -11,7 +11,6 @@ Feature: Configuration overrides
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "FixedSamplingProbabilitySpan1"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -22,7 +21,6 @@ Feature: Configuration overrides
     And I invoke "step2"
     And I wait to receive at least 1 span
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "FixedSamplingProbabilitySpan2"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -21,18 +21,16 @@ Feature: Initial P values
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
     * the sampling request "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
 
-    Then I wait to receive at least 1 span
+    Then I wait to receive a span named "First"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "First"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     Then I discard the oldest trace
     And I invoke "step2"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "Second"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "Second"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -23,7 +23,6 @@ Feature: Initial P values
 
     Then I wait to receive at least 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "First"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -33,7 +32,6 @@ Feature: Initial P values
     And I invoke "step2"
     And I wait to receive at least 1 span
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "Second"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -5,10 +5,9 @@ Feature: Manual Spans
 
   Scenario: Manual Span
     When I run "ManualSpanScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
@@ -19,24 +18,21 @@ Feature: Manual Spans
 
   Scenario: Manual Span isFirstClass false
     When I run "ManualSpanIsFirstClassFalseScenario"
-    And I wait to receive at least 1 span
-    Then every span field "name" equals "ManualSpanIsFirstClassFalseScenario"
+    And I wait to receive a span named "ManualSpanIsFirstClassFalseScenario"
     * every span bool attribute "bugsnag.span.first_class" is false
-
 
   Scenario: Max Batch Age
     When I run "MaxBatchAgeScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "MaxBatchAgeScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "MaxBatchAgeScenario"
 
   Scenario: Get Current Context
     When I run "GetCurrentContextScenario"
-    And I wait to receive at least 3 spans
-    * the span named "part 1: null" exists
-    * the span named "part 2: not null" exists
-    * the span named "context" is the parent of the span named "part 2: not null"    
+    And I wait to receive a span named "part 1: null"
+    * I wait to receive a span named "part 2: not null"
+    * I wait to receive a span named "context"
+    * the span named "context" is the parent of the span named "part 2: not null"
 
   @skip
   Scenario: Custom timings
@@ -54,10 +50,9 @@ Feature: Manual Spans
 
   Scenario: Manual Navigation Span
     When I run "ManualNavigationSpanScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "[Navigation]customNavigator/navigationScenarioRoute"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "[Navigation]customNavigator/navigationScenarioRoute"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
@@ -71,10 +66,9 @@ Feature: Manual Spans
 
   Scenario: Custom attributes
     When I run "CustomSpanAttributesScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "CustomSpanAttributesScenarioSpan"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "CustomSpanAttributesScenarioSpan"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
@@ -96,10 +90,9 @@ Feature: Manual Spans
 
   Scenario: Custom attributes - limits
     When I run "CustomSpanAttributesWithLimitsScenario"
-    And I wait to receive at least 1 span
+    And  I wait to receive a span named "CustomSpanAttributesWithLimitsScenarioSpan"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "CustomSpanAttributesWithLimitsScenarioSpan"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -7,7 +7,6 @@ Feature: Manual Spans
     When I run "ManualSpanScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
@@ -29,7 +28,6 @@ Feature: Manual Spans
     When I run "MaxBatchAgeScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "MaxBatchAgeScenario"
 
@@ -58,7 +56,6 @@ Feature: Manual Spans
     When I run "ManualNavigationSpanScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "[Navigation]customNavigator/navigationScenarioRoute"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
@@ -76,7 +73,6 @@ Feature: Manual Spans
     When I run "CustomSpanAttributesScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "CustomSpanAttributesScenarioSpan"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
@@ -102,7 +98,6 @@ Feature: Manual Spans
     When I run "CustomSpanAttributesWithLimitsScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "CustomSpanAttributesWithLimitsScenarioSpan"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"

--- a/features/nested_spans.feature
+++ b/features/nested_spans.feature
@@ -5,19 +5,17 @@ Feature: Nested Spans
 
   Scenario: Simple Nested Span
     When I run "SimpleNestedSpanScenario"
-    * I wait to receive at least 2 spans
-    * the span named "span1" exists
-    * the span named "span2" exists
+    *  I wait to receive a span named "span1"
+    *  I wait to receive a span named "span2"
     * the span named "span1" is the parent of the span named "span2"
     * the span named "span1" has no parent
 
   Scenario: New Zone New Context
     When I run "NewZoneNewContextScenario"
-    * I wait to receive at least 4 spans
-    * the span named "span1" exists
-    * the span named "span2" exists
-    * the span named "span3" exists
-    * the span named "span4" exists
+    *  I wait to receive a span named "span1"
+    *  I wait to receive a span named "span2"
+    *  I wait to receive a span named "span3"
+    *  I wait to receive a span named "span4"
 
     * the span named "span1" has no parent
     * the span named "span3" has no parent
@@ -27,10 +25,9 @@ Feature: Nested Spans
 
   Scenario: Pass Context To New Zone
     When I run "PassContextToNewZoneScenario"
-    * I wait to receive at least 3 spans
-    * the span named "span1" exists
-    * the span named "span2" exists
-    * the span named "span3" exists
+    *  I wait to receive a span named "span1"
+    *  I wait to receive a span named "span2"
+    *  I wait to receive a span named "span3"
 
     * the span named "span1" has no parent
 
@@ -39,10 +36,9 @@ Feature: Nested Spans
 
  Scenario: Make Current Context False
     When I run "MakeCurrentContextScenario"
-    * I wait to receive at least 3 spans
-    * the span named "span1" exists
-    * the span named "span2" exists
-    * the span named "span3" exists
+    *  I wait to receive a span named "span1"
+    *  I wait to receive a span named "span2"
+    *  I wait to receive a span named "span3"
 
     * the span named "span1" has no parent
 

--- a/features/network_spans.feature
+++ b/features/network_spans.feature
@@ -142,9 +142,8 @@ Feature: Network Spans
 
   Scenario: Network callback type
     When I run "CheckNetworkCallbackTypeScenario"
-    And I wait to receive at least 2 spans
+    And I wait to receive a span named "GET"
     Then the trace "Content-Type" header equals "application/json"
-    * the span named "GET" exists
 
   Scenario: Dart io trace parent header
     When I run "DartIoTraceparentScenario"

--- a/features/network_spans.feature
+++ b/features/network_spans.feature
@@ -7,7 +7,6 @@ Feature: Network Spans
     When I run "HttpGetScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
@@ -21,7 +20,6 @@ Feature: Network Spans
     When I run "HttpPostScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/POST"
@@ -37,7 +35,6 @@ Feature: Network Spans
     When I run "HttpGetMultipleSubscribersScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
@@ -46,7 +43,6 @@ Feature: Network Spans
     When I run "HttpCallbackEditScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
@@ -60,7 +56,6 @@ Feature: Network Spans
     When I run "HttpCallbackCancelSpan"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span bool attribute "bugsnag.span.first_class" is true
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HttpCallbackCancelSpanScenario"
@@ -86,7 +81,6 @@ Feature: Network Spans
     When I run "DIOGetScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
@@ -100,7 +94,6 @@ Feature: Network Spans
     When I run "DIOPostScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/POST"
@@ -115,7 +108,6 @@ Feature: Network Spans
     When I run "DIOCallbackEditScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"
@@ -129,7 +121,6 @@ Feature: Network Spans
     When I run "DIOCallbackCancelSpan"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "DIOCallbackCancelSpanScenario"
@@ -140,7 +131,6 @@ Feature: Network Spans
     When I run "DartIoGetScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "HTTP/GET"

--- a/features/resource_attributes.feature
+++ b/features/resource_attributes.feature
@@ -7,7 +7,6 @@ Feature: Resource Attributes
     When I run "CustomReleaseStageScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "CustomReleaseStageScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "CustomReleaseStageScenario"
@@ -16,7 +15,6 @@ Feature: Resource Attributes
     When I run "CustomEnabledReleaseStageScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "CustomEnabledReleaseStageScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "CustomEnabledReleaseStageScenario"
@@ -25,7 +23,6 @@ Feature: Resource Attributes
     When I run "CustomServiceNameScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "CustomServiceNameScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.custom.serviceName"
@@ -34,7 +31,6 @@ Feature: Resource Attributes
     When I run "CustomAppVersionScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
     * every span field "name" equals "CustomAppVersionScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "999.888.777"
@@ -47,7 +43,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -71,7 +66,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
@@ -89,7 +83,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive at least 1 span
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"

--- a/features/resource_attributes.feature
+++ b/features/resource_attributes.feature
@@ -5,34 +5,30 @@ Feature: Resource Attributes
 
   Scenario: Custom release stage
     When I run "CustomReleaseStageScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "CustomReleaseStageScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "CustomReleaseStageScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "CustomReleaseStageScenario"
 
   Scenario: Custom enabled release stage
     When I run "CustomEnabledReleaseStageScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "CustomEnabledReleaseStageScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "CustomEnabledReleaseStageScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "CustomEnabledReleaseStageScenario"
 
   Scenario: Custom service name
     When I run "CustomServiceNameScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "CustomServiceNameScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "CustomServiceNameScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.name" equals "com.custom.serviceName"
 
   Scenario: Custom app version
     When I run "CustomAppVersionScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "CustomAppVersionScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "name" equals "CustomAppVersionScenario"
     * the trace payload field "resourceSpans.0.resource" string attribute "service.version" equals "999.888.777"
 
   Scenario: Disabled release stage
@@ -41,9 +37,8 @@ Feature: Resource Attributes
 
   Scenario: Common Attributes
     When I run "ManualSpanScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
@@ -64,9 +59,8 @@ Feature: Resource Attributes
   @android_only
   Scenario: Android Attributes
     When I run "ManualSpanScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
@@ -81,9 +75,8 @@ Feature: Resource Attributes
   @ios_only
   Scenario: iOS Attributes
     When I run "ManualSpanScenario"
-    And I wait to receive at least 1 span
+    And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "name" equals "ManualSpanScenario"
     * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
     * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"

--- a/features/span_control.feature
+++ b/features/span_control.feature
@@ -5,20 +5,18 @@ Feature: span control
 
   Scenario: Custom AppStart span name
     Given I run "SetCustomAppStartNameScenario"
-    And I wait to receive at least 4 spans
-    * a span field "name" equals "[AppStart/FlutterInit]FirstOpen"
-    * a span field "name" equals "[AppStartPhase/pre runApp()]"
-    * a span field "name" equals "[AppStartPhase/runApp()]"
-    * a span field "name" equals "[AppStartPhase/UI init]"
+    And I wait to receive a span named "[AppStart/FlutterInit]FirstOpen"
+    * I wait to receive a span named "[AppStartPhase/pre runApp()]"
+    * I wait to receive a span named "[AppStartPhase/runApp()]"
+    * I wait to receive a span named "[AppStartPhase/UI init]"
     * every span string attribute "bugsnag.app_start.type" equals "FlutterInit"
     * a span string attribute "bugsnag.app_start.name" equals "FirstOpen"
 
   Scenario: Clear custom AppStart span name
     Given I run "ClearCustomAppStartNameScenario"
-    And I wait to receive at least 4 spans
-    * a span field "name" equals "[AppStart/FlutterInit]"
-    * a span field "name" equals "[AppStartPhase/pre runApp()]"
-    * a span field "name" equals "[AppStartPhase/runApp()]"
-    * a span field "name" equals "[AppStartPhase/UI init]"
+    And I wait to receive a span named "[AppStart/FlutterInit]"
+    * I wait to receive a span named "[AppStartPhase/pre runApp()]"
+    * I wait to receive a span named "[AppStartPhase/runApp()]"
+    * I wait to receive a span named "[AppStartPhase/UI init]"
     * every span string attribute "bugsnag.app_start.type" equals "FlutterInit"
     * every span string attribute "bugsnag.app_start.name" does not exist


### PR DESCRIPTION
## Goal

Update all e2e test scenarios to wait for spans by name.

## Design

This is just a small part of a much wider effort to reconcile the Cucumber step definitions that we have.  This particular change removes all uses of steps that start `a span field`.

## Changeset

I was also able to remove all uses of the step `the trace "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"`, as Maze Runner checks this on every trace for us.

## Testing

Covered by CI.