### PR TITLE
Remove redundant and unused Cucumber steps

### DIFF
--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -11,8 +11,6 @@ Feature: Automatic instrumentation spans
     * I wait to receive a span named "[AppStartPhase/UI init]"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:4"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span string attribute "bugsnag.phase" equals "pre runApp()"
@@ -36,8 +34,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -54,8 +50,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -78,8 +72,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -117,8 +109,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "nested_scenario_child_route_2"
     * a span string attribute "bugsnag.navigation.navigator" equals "nested_scenario_child_navigator"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -138,8 +128,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "pop"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "push_and_pop_scenario"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -156,8 +144,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.phase" equals "building"
     * a span string attribute "bugsnag.phase" equals "appearing"
     * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/loading content" exists
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -179,8 +165,6 @@ Feature: Automatic instrumentation spans
     * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * a span string attribute "bugsnag.phase" equals "loading content"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -209,8 +193,6 @@ Feature: Automatic instrumentation spans
     * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * a span string attribute "bugsnag.phase" equals "loading content"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
@@ -251,8 +233,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.phase" equals "loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load_phase"
     * a span string attribute "bugsnag.span.category" equals "view_load"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -11,8 +11,6 @@ Feature: Configuration overrides
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     Then I discard the oldest trace
@@ -20,8 +18,6 @@ Feature: Configuration overrides
     And I invoke "step2"
     And I wait to receive a span named "FixedSamplingProbabilitySpan2"
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -23,16 +23,12 @@ Feature: Initial P values
 
     Then I wait to receive a span named "First"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     Then I discard the oldest trace
     And I invoke "step2"
     And I wait to receive a span named "Second"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -8,8 +8,6 @@ Feature: Manual Spans
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" is true
@@ -53,8 +51,6 @@ Feature: Manual Spans
     And I wait to receive a span named "[Navigation]customNavigator/navigationScenarioRoute"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "navigation"
@@ -69,8 +65,6 @@ Feature: Manual Spans
     And I wait to receive a span named "CustomSpanAttributesScenarioSpan"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "droppedAttributesCount" does not exist
@@ -93,8 +87,6 @@ Feature: Manual Spans
     And  I wait to receive a span named "CustomSpanAttributesWithLimitsScenarioSpan"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "droppedAttributesCount" equals 3

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -41,9 +41,8 @@ Feature: Manual Spans
 
   Scenario: Span With No Parent
     When I run "SpanWithNoParentScenario"
-    And I wait to receive at least 2 spans
-    * the span named "parent" exists
-    * the span named "no-parent" exists
+    And I wait to receive a span named "parent"
+    * I wait to receive a span named "no-parent"
     * the span named "no-parent" has no parent
 
   Scenario: Manual Navigation Span

--- a/features/resource_attributes.feature
+++ b/features/resource_attributes.feature
@@ -39,8 +39,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
@@ -61,8 +59,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
@@ -77,8 +73,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * every span field "traceId" matches the regex "^[A-Fa-f0-9]{32}$"
     * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 

--- a/features/steps/flutter_steps.rb
+++ b/features/steps/flutter_steps.rb
@@ -78,23 +78,11 @@ Then('every span string attribute {string} does not exist') do |attribute|
   spans.map { |span| Maze.check.nil span['attributes'].find { |a| a['key'] == attribute } }
 end
 
-Then('all span bool attribute {string} is true') do |attribute|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
-  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact
-  selected_attributes.map { |a| Maze::check.true a['value']['boolValue'] }
-end
-
 Then('a span bool attribute {string} is true') do |attribute|
   spans = spans_from_request_list(Maze::Server.list_for('traces'))
   selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact
   selected_attributes = selected_attributes.map { |a| a['value']['boolValue'] == true }
   Maze.check.false(selected_attributes.empty?)
-end
-
-Then('all span bool attribute {string} is false') do |attribute|
-  spans = spans_from_request_list(Maze::Server.list_for('traces'))
-  selected_attributes = spans.map { |span| span['attributes'].find { |a| a['key'].eql?(attribute) && a['value'].has_key?('boolValue') } }.compact
-  selected_attributes.map { |a| Maze::check.false a['value']['boolValue'] }
 end
 
 Then('a span bool attribute {string} is false') do |attribute|
@@ -174,13 +162,6 @@ When('I invoke {string}') do |method_name|
   sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
   raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
 end
-Then('the span named {string} exists') do |span_name|
-  spans = spans_from_request_list(Maze::Server.list_for("traces"))
-
-  spans_with_name = spans.find_all { |span| span['name'].eql?(span_name) }
-
-  Maze.check.true(spans_with_name.length() == 1);
-end
 
 Then('the span named {string} is the parent of the span named {string}') do |span1name, span2name|
   
@@ -249,11 +230,6 @@ end
 Then('a span array attribute {string} contains {int} items') do |attribute, length|
   array = get_array_attribute_contents(attribute)
   Maze.check.true(array.length() == length)
-end
-
-Then('a span array attribute {string} is empty') do |attribute|
-  array_contents = get_array_attribute_contents(attribute)
-  Maze.check.true(array_contents.empty?)
 end
 
 def get_array_value_at_index(attribute, index, type)


### PR DESCRIPTION
## Goal

Improve maintainability of the e2e tests by removing redundant and unused Cucumber steps.  

##  Changeset

- The checks on the `spanId` and `traceId` are performed by Maze Runner for all received spans and so these can be removed.
- A number of custom step definitions were unused in this repo and can simply be removed.

## Testing

Covered by CI.