### PR TITLE
Pin iOS tests to Appium 2.0.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,7 @@ steps:
         upload:
           - "features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
 
-  - label: ":bitbar: iOS 14 end-to-end tests"
+  - label: ":bitbar: iOS end-to-end tests"
     depends_on: "ios-fixture-3-10-0"
     timeout_in_minutes: 20
     env:
@@ -59,7 +59,7 @@ steps:
           - "--fail-fast"
           - "--no-tunnel"
           - "--aws-public-ip"
-          - "--appium-version=1.22"
+          - "--appium-version=2.0.1"
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"


### PR DESCRIPTION
## Goal

Fix an error in the e2e tests caused by the touch operation being removed in later versions of Appium.  

## Design

Ultimately, in the future we'll remove the touch operation completely by polling for idempotent commands, this is just a quick fix to keep things running for now.

## Testing

Covered by CI.