### PR TITLE
Avoid Appium 2.5.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,11 +55,11 @@ steps:
         command:
           - "--app=/app/features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
           - "--farm=bb"
-          - "--device=IOS_15|IOS_16|IOS_17|IOS_18"
+          # Avoid iOS 17 for now as it will force us to Appium 2.5, where the Touch we perform will fail.
+          - "--device=IOS_14|IOS_15|IOS_16"
           - "--fail-fast"
           - "--no-tunnel"
           - "--aws-public-ip"
-          - "--appium-version=2.0.1"
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
@@ -90,7 +90,7 @@ steps:
         upload:
           - "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
 
-  - label: ":bitbar: Android 12 end-to-end tests 3.19.0"
+  - label: ":bitbar: Android end-to-end tests 3.19.0"
     depends_on: "android-fixture-3-10-0"
     timeout_in_minutes: 20
     env:


### PR DESCRIPTION
## Goal

Avoid Appium 2.5.0 - by not using iOS 17.

## Design

My last PR was incomplete - on BitBar, with iOS, the Appium version it not determined by the capability, it's determined by the iOS version.

## Testing

Covered by CI.