### PR TITLE
Remove redundant Cucumber steps

### DIFF
--- a/features/automatic_spans.feature
+++ b/features/automatic_spans.feature
@@ -11,8 +11,6 @@ Feature: Automatic instrumentation spans
     * I wait to receive a span named "[AppStartPhase/UI init]"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:4"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * a span string attribute "bugsnag.phase" equals "pre runApp()"
     * a span string attribute "bugsnag.phase" equals "runApp()"
     * a span string attribute "bugsnag.phase" equals "UI init"
@@ -34,8 +32,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
 
   Scenario: AutoInstrumentNavigationBasicDeferScenario
@@ -50,8 +46,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
 
   Scenario: AutoInstrumentNavigationComplexDeferScenario
@@ -72,8 +66,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "push"
     * a span string attribute "bugsnag.navigation.ended_by" equals "loading_indicator"
     * a span string attribute "bugsnag.navigation.previous_route" equals "/"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
 
   Scenario: AutoInstrumentNavigationNestedNavigationScenario
@@ -109,8 +101,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "nested_scenario_child_route_2"
     * a span string attribute "bugsnag.navigation.navigator" equals "nested_scenario_child_navigator"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
 
   Scenario: AutoInstrumentNavigationPushAndPopScenario
@@ -128,8 +118,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.navigation.triggered_by" equals "pop"
     * a span string attribute "bugsnag.navigation.ended_by" equals "frame_render"
     * a span string attribute "bugsnag.navigation.previous_route" equals "push_and_pop_scenario"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
 
   Scenario: AutoInstrumentViewLoadBasicScenario
@@ -144,8 +132,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.phase" equals "building"
     * a span string attribute "bugsnag.phase" equals "appearing"
     * no span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/loading content" exists
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/building"
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicScenarioWidget/appearing"
@@ -165,8 +151,6 @@ Feature: Automatic instrumentation spans
     * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * a span string attribute "bugsnag.phase" equals "loading content"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/building"
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadBasicDeferScenarioWidget/appearing"
@@ -193,8 +177,6 @@ Feature: Automatic instrumentation spans
     * I wait to receive a span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioChildWidget/loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load"
     * a span string attribute "bugsnag.phase" equals "loading content"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/building"
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentViewLoadNestedScenarioWidget/appearing"
@@ -233,8 +215,6 @@ Feature: Automatic instrumentation spans
     * a span string attribute "bugsnag.phase" equals "loading content"
     * a span string attribute "bugsnag.span.category" equals "view_load_phase"
     * a span string attribute "bugsnag.span.category" equals "view_load"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" does not exist
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/building"
     * the span named "[ViewLoad]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget" is the parent of the span named "[ViewLoadPhase]FlutterWidget/AutoInstrumentNavigationWithViewLoadWidget/appearing"

--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -9,17 +9,12 @@ Feature: Configuration overrides
     And I run "FixedSamplingProbabilityOneScenario"
     And I wait to receive a span named "FixedSamplingProbabilitySpan1"
     Then the trace "Content-Type" header equals "application/json"
-    * the trace "Bugsnag-Integrity" header matches the regex "^sha1 [A-Fa-f0-9]{40}$"
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     Then I discard the oldest trace
     Then I set the sampling probability for the next traces to "0"
     And I invoke "step2"
     And I wait to receive a span named "FixedSamplingProbabilitySpan2"
     * the trace "Bugsnag-Span-Sampling" header is not present
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
   Scenario: Setting fixed sampling probability of 0 with dynamic probability of 1 should send no spans
     Given I set the sampling probability for the next traces to "0"

--- a/features/correlation.feature
+++ b/features/correlation.feature
@@ -9,9 +9,6 @@ Feature: Error correlation
     * I wait to receive at least 1 span
     * the exception "message" equals "CorrelationSimpleScenario"
 
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" matches the regex "^[A-Fa-f0-9]{16}$"
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" matches the regex "^[A-Fa-f0-9]{32}$"
-
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.spanId" is stored as the value "context_span_id"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.traceId" is stored as the value "context_trace_id"
 

--- a/features/initial-p-value.feature
+++ b/features/initial-p-value.feature
@@ -8,7 +8,6 @@ Feature: Initial P values
     And I run "InitialPScenario"
     And I wait to receive a sampling request
     * the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
-    * the sampling request "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the sampling request payload field "resourceSpans" is an array with 0 elements
     Then I invoke "step2"
     And I should receive no traces
@@ -19,22 +18,16 @@ Feature: Initial P values
     And I wait to receive a sampling request
 
     Then the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
-    * the sampling request "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
 
     Then I wait to receive a span named "First"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     Then I discard the oldest trace
     And I invoke "step2"
     And I wait to receive a span named "Second"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
   Scenario: ProbabilityExpiryScenario
     Given I run "ProbabilityExpiryScenario"
     And I wait to receive at least 1 sampling request
     * the sampling request "Bugsnag-Span-Sampling" header equals "1:0"
-    * the sampling request "Bugsnag-Sent-At" header matches the regex "^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\dZ$"
     * the sampling request payload field "resourceSpans" is an array with 0 elements

--- a/features/manual_span.feature
+++ b/features/manual_span.feature
@@ -8,8 +8,6 @@ Feature: Manual Spans
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span bool attribute "bugsnag.span.first_class" is true
     * every span string attribute "bugsnag.span.category" equals "custom"
     * a span double attribute "bugsnag.sampling.p" equals 1.0
@@ -50,8 +48,6 @@ Feature: Manual Spans
     And I wait to receive a span named "[Navigation]customNavigator/navigationScenarioRoute"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span string attribute "bugsnag.span.category" equals "navigation"
     * every span string attribute "bugsnag.navigation.route" equals "navigationScenarioRoute"
     * every span string attribute "bugsnag.navigation.navigator" equals "customNavigator"
@@ -64,8 +60,6 @@ Feature: Manual Spans
     And I wait to receive a span named "CustomSpanAttributesScenarioSpan"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "droppedAttributesCount" does not exist
     * every span bool attribute "bugsnag.span.first_class" is true
     * every span string attribute "bugsnag.span.category" equals "custom"
@@ -86,8 +80,6 @@ Feature: Manual Spans
     And  I wait to receive a span named "CustomSpanAttributesWithLimitsScenarioSpan"
     Then the trace "Content-Type" header equals "application/json"
     * the trace "Bugsnag-Span-Sampling" header equals "1:1"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
     * every span field "droppedAttributesCount" equals 3
     * every span bool attribute "bugsnag.span.first_class" is true
     * every span string attribute "bugsnag.span.category" equals "custom"

--- a/features/resource_attributes.feature
+++ b/features/resource_attributes.feature
@@ -39,8 +39,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
     * the trace payload field "resourceSpans.0.resource" string attribute "deployment.environment" equals "development"
     * the trace payload field "resourceSpans.0.resource" string attribute "telemetry.sdk.name" equals "bugsnag.performance.flutter"
@@ -59,8 +57,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.platform" equals "android"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.version_code" equals "1"
@@ -73,8 +69,6 @@ Feature: Resource Attributes
     When I run "ManualSpanScenario"
     And I wait to receive a span named "ManualSpanScenario"
     Then the trace "Content-Type" header equals "application/json"
-    * every span field "startTimeUnixNano" matches the regex "^[0-9]+$"
-    * every span field "endTimeUnixNano" matches the regex "^[0-9]+$"
 
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.platform" equals "ios"
     * the trace payload field "resourceSpans.0.resource" string attribute "bugsnag.app.bundle_version" equals "1"


### PR DESCRIPTION
## Goal

Remove redundant Cucumber steps - these checks are now all performed in Maze Runner for all traces recived.

## Testing

Covered by CI.