### PR TITLE
Bump Flutter versions used on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
 
   - group: "End-to-End Tests"
     steps:
-      - label: ":bitbar: iOS end-to-end tests"
+      - label: ":bitbar: Flutter {{matrix}} iOS end-to-end tests"
         depends_on: "ios-fixture"
         timeout_in_minutes: 20
         matrix:
@@ -105,7 +105,7 @@ steps:
             - exit_status: 103  # Appium session failed
               limit: 2
 
-      - label: ":bitbar: Android end-to-end tests 3.19.0"
+      - label: ":bitbar: Flutter {{matrix}} Android end-to-end tests"
         depends_on: "android-fixture"
         timeout_in_minutes: 20
         matrix:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,9 +38,6 @@ steps:
         env:
           FLUTTER_VERSION: "{{matrix}}"
         commands:
-          - "bundle install"
-          - "pod repo update trunk"
-          - "features/scripts/generate_fixture.sh"
           - "features/scripts/build_ios_app.sh"
         plugins:
           artifacts#v1.5.0:
@@ -58,8 +55,6 @@ steps:
         env:
           FLUTTER_VERSION: "{{matrix}}"
         commands:
-          - "bundle install"
-          - "features/scripts/generate_fixture.sh"
           - "features/scripts/build_android_app.sh"
         plugins:
           artifacts#v1.5.0:
@@ -67,96 +62,86 @@ steps:
               from: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
               to: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release-{{matrix}}.apk"
 
+  - group: "End-to-End Tests"
+    steps:
+      - label: ":bitbar: iOS end-to-end tests"
+        depends_on: "ios-fixture"
+        timeout_in_minutes: 20
+        matrix:
+          - "3.38.3"
+          - "3.24.4"
+          - "3.19.0"
+        env:
+          FLUTTER_VERSION: "{{matrix}}"
+        agents:
+          queue: "opensource"
+        plugins:
+          artifacts#v1.5.0:
+            download: "features/fixtures/mazerunner/build/ios/ipa/mazerunner-{{matrix}}.ipa"
+            upload:
+              - "maze_output/failed/**/*"
+              - "maze_output/maze_output.zip"
+          docker-compose#v4.7.0:
+            pull: "maze-runner"
+            run: "maze-runner"
+            service-ports: true
+            command:
+              - "--app=/app/features/fixtures/mazerunner/build/ios/ipa/mazerunner-{{matrix}}.ipa"
+              - "--farm=bb"
+              # Avoid iOS 17 for now as it will force us to Appium 2.5, where the Touch we perform will fail.
+              - "--device=IOS_14|IOS_15|IOS_16"
+              - "--fail-fast"
+              - "--no-tunnel"
+              - "--aws-public-ip"
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: "eager"
+        retry:
+          automatic:
+            - exit_status: 103  # Appium session failed
+              limit: 2
 
-#
-#  - label: ":bitbar: iOS end-to-end tests"
-#    depends_on: "ios-fixture-3-10-0"
-#    timeout_in_minutes: 20
-#    env:
-#      FLUTTER_VERSION: "3.19.0"
-#    agents:
-#      queue: "opensource"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download: "features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/maze_output.zip"
-#      docker-compose#v4.7.0:
-#        pull: "maze-runner"
-#        run: "maze-runner"
-#        service-ports: true
-#        command:
-#          - "--app=/app/features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
-#          - "--farm=bb"
-#          # Avoid iOS 17 for now as it will force us to Appium 2.5, where the Touch we perform will fail.
-#          - "--device=IOS_14|IOS_15|IOS_16"
-#          - "--fail-fast"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    concurrency: 25
-#    concurrency_group: "bitbar"
-#    concurrency_method: "eager"
-#    retry:
-#      automatic:
-#        - exit_status: 103  # Appium session failed
-#          limit: 2
-#
-#  #
-#  # Android
-#  #
-#  - label: "Build Android Test Fixture"
-#    key: "android-fixture-3-10-0"
-#    timeout_in_minutes: 20
-#    env:
-#      FLUTTER_VERSION: "3.19.0"
-#      JAVA_VERSION: "17"
-#    commands:
-#      - "bundle install"
-#      - "features/scripts/generate_fixture.sh"
-#      - "features/scripts/build_android_app.sh"
-#    plugins:
-#      artifacts#v1.5.0:
-#        upload:
-#          - "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
-#
-#  - label: ":bitbar: Android end-to-end tests 3.19.0"
-#    depends_on: "android-fixture-3-10-0"
-#    timeout_in_minutes: 20
-#    env:
-#      FLUTTER_VERSION: "3.19.0"
-#    agents:
-#      queue: "opensource"
-#    plugins:
-#      artifacts#v1.5.0:
-#        download: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/maze_output.zip"
-#      docker-compose#v4.7.0:
-#        pull: "maze-runner"
-#        run: "maze-runner"
-#        service-ports: true
-#        command:
-#          - "--app=features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
-#          - "--farm=bb"
-#          - "--device=ANDROID_13|ANDROID_14|ANDROID_15|ANDROID_16"
-#          - "--fail-fast"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--appium-version=1.22"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    concurrency: 25
-#    concurrency_group: "bitbar"
-#    concurrency_method: "eager"
-#    retry:
-#      automatic:
-#        - exit_status: 103  # Appium session failed
-#          limit: 2
+      - label: ":bitbar: Android end-to-end tests 3.19.0"
+        depends_on: "android-fixture"
+        timeout_in_minutes: 20
+        matrix:
+          - "3.38.3"
+          - "3.24.4"
+          - "3.19.0"
+        env:
+          FLUTTER_VERSION: "{{matrix}}"
+        agents:
+          queue: "opensource"
+        plugins:
+          artifacts#v1.5.0:
+            download: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release-{{matrix}}.apk"
+            upload:
+              - "maze_output/failed/**/*"
+              - "maze_output/maze_output.zip"
+          docker-compose#v4.7.0:
+            pull: "maze-runner"
+            run: "maze-runner"
+            service-ports: true
+            command:
+              - "--app=features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release-{{matrix}}.apk"
+              - "--farm=bb"
+              - "--device=ANDROID_13|ANDROID_14|ANDROID_15|ANDROID_16"
+              - "--fail-fast"
+              - "--no-tunnel"
+              - "--aws-public-ip"
+              - "--appium-version=1.22"
+          test-collector#v1.10.2:
+            files: "reports/TEST-*.xml"
+            format: "junit"
+            branch: "^main|next$$"
+        concurrency: 25
+        concurrency_group: "bitbar"
+        concurrency_method: "eager"
+        retry:
+          automatic:
+            - exit_status: 103  # Appium session failed
+              limit: 2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,128 +1,162 @@
 agents:
   queue: "macos-15"
 
+env:
+  JAVA_VERSION: "17"
+  XCODE_VERSION: "26.1.1"
+
 steps:
+  - group: "Unit Tests"
+    steps:
+      - label: ":test_tube: {{matrix}}"
+        matrix:
+          - "3.38.3"
+          - "3.24.4"
+          - "3.19.0"
+        timeout_in_minutes: 10
+        env:
+          FLUTTER_VERSION: "{{matrix}}"
+        commands:
+          - "make test"
 
-  - label: ":test_tube: 3.19.0"
+  - label: ":lint-roller: 3.38.3"
     timeout_in_minutes: 10
     env:
-      FLUTTER_VERSION: "3.19.0"
-    commands:
-      - "make test"
-
-  - label: ":lint-roller: 3.19.0"
-    timeout_in_minutes: 10
-    env:
-      FLUTTER_VERSION: "3.19.0"
+      FLUTTER_VERSION: "3.38.3"
     commands:
       - "make lint"
 
-  #
-  # iOS
-  #
-  - label: "Build iOS Test Fixture"
-    key: "ios-fixture-3-10-0"
-    timeout_in_minutes: 20
-    env:
-      FLUTTER_VERSION: "3.19.0"
-    commands:
-      - "bundle install"
-      - "pod repo update trunk"
-      - "features/scripts/generate_fixture.sh"
-      - "features/scripts/build_ios_app.sh"
-    plugins:
-      artifacts#v1.5.0:
-        upload:
-          - "features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
+  - group: "Build Fixtures"
+    steps:
+      - label: "Build iOS Test Fixture {{matrix}}"
+        key: "ios-fixture"
+        matrix:
+          - "3.38.3"
+          - "3.24.4"
+          - "3.19.0"
+        timeout_in_minutes: 20
+        env:
+          FLUTTER_VERSION: "{{matrix}}"
+        commands:
+          - "bundle install"
+          - "pod repo update trunk"
+          - "features/scripts/generate_fixture.sh"
+          - "features/scripts/build_ios_app.sh"
+        plugins:
+          artifacts#v1.5.0:
+            upload:
+              from: "features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
+              to: "features/fixtures/mazerunner/build/ios/ipa/mazerunner-{{matrix}}.ipa"
 
-  - label: ":bitbar: iOS end-to-end tests"
-    depends_on: "ios-fixture-3-10-0"
-    timeout_in_minutes: 20
-    env:
-      FLUTTER_VERSION: "3.19.0"
-    agents:
-      queue: "opensource"
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: "maze-runner"
-        run: "maze-runner"
-        service-ports: true
-        command:
-          - "--app=/app/features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
-          - "--farm=bb"
-          # Avoid iOS 17 for now as it will force us to Appium 2.5, where the Touch we perform will fail.
-          - "--device=IOS_14|IOS_15|IOS_16"
-          - "--fail-fast"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    concurrency: 25
-    concurrency_group: "bitbar"
-    concurrency_method: "eager"
-    retry:
-      automatic:
-        - exit_status: 103  # Appium session failed
-          limit: 2
+      - label: "Build Android Test Fixture {{matrix}}"
+        key: "android-fixture"
+        matrix:
+          - "3.38.3"
+          - "3.24.4"
+          - "3.19.0"
+        timeout_in_minutes: 20
+        env:
+          FLUTTER_VERSION: "{{matrix}}"
+        commands:
+          - "bundle install"
+          - "features/scripts/generate_fixture.sh"
+          - "features/scripts/build_android_app.sh"
+        plugins:
+          artifacts#v1.5.0:
+            upload:
+              from: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
+              to: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release-{{matrix}}.apk"
 
-  #
-  # Android
-  #
-  - label: "Build Android Test Fixture"
-    key: "android-fixture-3-10-0"
-    timeout_in_minutes: 20
-    env:
-      FLUTTER_VERSION: "3.19.0"
-      JAVA_VERSION: "17"
-    commands:
-      - "bundle install"
-      - "features/scripts/generate_fixture.sh"
-      - "features/scripts/build_android_app.sh"
-    plugins:
-      artifacts#v1.5.0:
-        upload:
-          - "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
 
-  - label: ":bitbar: Android end-to-end tests 3.19.0"
-    depends_on: "android-fixture-3-10-0"
-    timeout_in_minutes: 20
-    env:
-      FLUTTER_VERSION: "3.19.0"
-    agents:
-      queue: "opensource"
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: "maze-runner"
-        run: "maze-runner"
-        service-ports: true
-        command:
-          - "--app=features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
-          - "--farm=bb"
-          - "--device=ANDROID_13|ANDROID_14|ANDROID_15|ANDROID_16"
-          - "--fail-fast"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--appium-version=1.22"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    concurrency: 25
-    concurrency_group: "bitbar"
-    concurrency_method: "eager"
-    retry:
-      automatic:
-        - exit_status: 103  # Appium session failed
-          limit: 2
+#
+#  - label: ":bitbar: iOS end-to-end tests"
+#    depends_on: "ios-fixture-3-10-0"
+#    timeout_in_minutes: 20
+#    env:
+#      FLUTTER_VERSION: "3.19.0"
+#    agents:
+#      queue: "opensource"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download: "features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/maze_output.zip"
+#      docker-compose#v4.7.0:
+#        pull: "maze-runner"
+#        run: "maze-runner"
+#        service-ports: true
+#        command:
+#          - "--app=/app/features/fixtures/mazerunner/build/ios/ipa/mazerunner.ipa"
+#          - "--farm=bb"
+#          # Avoid iOS 17 for now as it will force us to Appium 2.5, where the Touch we perform will fail.
+#          - "--device=IOS_14|IOS_15|IOS_16"
+#          - "--fail-fast"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    concurrency: 25
+#    concurrency_group: "bitbar"
+#    concurrency_method: "eager"
+#    retry:
+#      automatic:
+#        - exit_status: 103  # Appium session failed
+#          limit: 2
+#
+#  #
+#  # Android
+#  #
+#  - label: "Build Android Test Fixture"
+#    key: "android-fixture-3-10-0"
+#    timeout_in_minutes: 20
+#    env:
+#      FLUTTER_VERSION: "3.19.0"
+#      JAVA_VERSION: "17"
+#    commands:
+#      - "bundle install"
+#      - "features/scripts/generate_fixture.sh"
+#      - "features/scripts/build_android_app.sh"
+#    plugins:
+#      artifacts#v1.5.0:
+#        upload:
+#          - "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
+#
+#  - label: ":bitbar: Android end-to-end tests 3.19.0"
+#    depends_on: "android-fixture-3-10-0"
+#    timeout_in_minutes: 20
+#    env:
+#      FLUTTER_VERSION: "3.19.0"
+#    agents:
+#      queue: "opensource"
+#    plugins:
+#      artifacts#v1.5.0:
+#        download: "features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/maze_output.zip"
+#      docker-compose#v4.7.0:
+#        pull: "maze-runner"
+#        run: "maze-runner"
+#        service-ports: true
+#        command:
+#          - "--app=features/fixtures/mazerunner/build/app/outputs/flutter-apk/app-release.apk"
+#          - "--farm=bb"
+#          - "--device=ANDROID_13|ANDROID_14|ANDROID_15|ANDROID_16"
+#          - "--fail-fast"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--appium-version=1.22"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    concurrency: 25
+#    concurrency_group: "bitbar"
+#    concurrency_method: "eager"
+#    retry:
+#      automatic:
+#        - exit_status: 103  # Appium session failed
+#          limit: 2

--- a/features/scripts/build_android_app.sh
+++ b/features/scripts/build_android_app.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 set -o errexit
+set -o pipefail
+set -o nounset
 
-if [ -z "$FLUTTER_BIN" ]; then
+if [[ -z "${FLUTTER_BIN:-}" ]]; then
   FLUTTER_BIN="flutter"
+  echo "FLUTTER_BIN not set; defaulting to 'flutter'"
 fi
 
-echo "Flutter Bin: $FLUTTER_BIN"
+echo "--- 📦 Bundle Install"
+if ! bundle install; then
+  echo "Warning: bundle install failed but continuing"
+fi
 
+echo "--- 🔧 Generate Fixture"
+echo "Running generate_fixture.sh script"
+./features/scripts/generate_fixture.sh
+
+echo "--- 🚀 Building Flutter APK"
 cd features/fixtures/mazerunner
-$FLUTTER_BIN build apk --no-tree-shake-icons
+"$FLUTTER_BIN" build apk --no-tree-shake-icons

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -1,12 +1,45 @@
 #!/usr/bin/env bash
 set -o errexit
+set -o pipefail
+set -o nounset
 
-if [ -z "$FLUTTER_BIN" ]; then
+if [[ -z "${FLUTTER_BIN:-}" ]]; then
   FLUTTER_BIN="flutter"
+  echo "FLUTTER_BIN not set; defaulting to 'flutter'"
 fi
 
+echo "--- 📦 Bundle Install"
+if ! bundle install; then
+  echo "Warning: bundle install failed but continuing"
+fi
+
+echo "--- ☁️ Updating CocoaPods"
+if ! pod repo update trunk; then
+  echo "Warning: pod repo update trunk failed but continuing"
+fi
+
+echo "--- 🔧 Generate Fixture"
+echo "Running generate_fixture.sh script"
+./features/scripts/generate_fixture.sh
+
+
+
+echo "--- 🚧 Running xcodebuild to set provisioning profile (failure allowed)..."
 EXPORT_OPTIONS="$(pwd)/features/fixture_resources/exportOptions.plist"
+echo "Using export options plist at: \"$EXPORT_OPTIONS\""
 
-cd features/fixtures/mazerunner/ios
+IOS_DIR="features/fixtures/mazerunner/ios"
+echo "Changing directory to \"$IOS_DIR\""
+cd "$IOS_DIR"
 
-$FLUTTER_BIN build ipa --export-options-plist=$EXPORT_OPTIONS --no-tree-shake-icons
+xcodebuild build \
+  -workspace "./Runner.xcworkspace" \
+  -scheme "Runner" \
+  -configuration "Release" \
+  -allowProvisioningUpdates | tee xcodebuild.log || echo "xcodebuild failed but continuing as expected"
+
+echo "--- 🚀 Building Flutter IPA"
+echo "Running flutter build ipa command"
+"$FLUTTER_BIN" build ipa \
+  --export-options-plist="$EXPORT_OPTIONS" \
+  --no-tree-shake-icons

--- a/features/scripts/generate_fixture.sh
+++ b/features/scripts/generate_fixture.sh
@@ -13,9 +13,6 @@ HTTP_WRAPPER_PACKAGE_PATH="$(pwd)/packages/bugsnag-flutter-common/packages/bugsn
 
 DART_IO_WRAPPER_PACKAGE_PATH="$(pwd)/packages/bugsnag-flutter-common/packages/bugsnag_flutter_dart_io_http_client"
 
-
-
-
 EXPORT_OPTIONS=features/fixture_resources/exportOptions.plist
 
 XCODE_PROJECT=features/fixtures/mazerunner/ios/Runner.xcodeproj/project.pbxproj
@@ -32,10 +29,14 @@ BS_DART_LOCATION=features/fixture_resources/lib
 
 BS_DART_DESTINATION=features/fixtures/mazerunner
 
-ANDROID_GRADLE=features/fixtures/mazerunner/android/app/build.gradle
+# If flutter version = 3.38.3 or higher, change min sdk to 19
+if $FLUTTER_BIN --version | grep -qE 'Flutter 3\.(3[8-9]|[4-9][0-9]|[1-9][0-9]{2,})'; then
+  ANDROID_GRADLE=features/fixtures/mazerunner/android/app/build.gradle.kts
+else
+  ANDROID_GRADLE=features/fixtures/mazerunner/android/app/build.gradle
+fi
 
 PODFILE=features/fixtures/mazerunner/ios/Podfile
-
 
 echo "Remove old fixture"
 
@@ -53,7 +54,15 @@ $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" path_provider
 
 $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" http
 
-$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "native_flutter_proxy:0.1.15"
+if $FLUTTER_BIN --version | grep -qE 'Flutter 3\.(2[0-9]|[3-9][0-9]|[1-9][0-9]{2,})'; then
+  echo "Using local native_flutter_proxy package for flutter version >= 3.20.0"
+  $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "native_flutter_proxy"
+  sed -i '' "s|import 'package:native_flutter_proxy/custom_proxy.dart';|import 'package:native_flutter_proxy/src/custom_proxy.dart';|" $BS_DART_LOCATION/main.dart
+  sed -i '' "s|import 'package:native_flutter_proxy/native_proxy_reader.dart';|import 'package:native_flutter_proxy/src/native_proxy_reader.dart';|" $BS_DART_LOCATION/main.dart
+else
+  $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "native_flutter_proxy:0.1.15"
+fi
+
 #$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "bugsnag_http_client:{'path':'$HTTP_WRAPPER_PACKAGE_PATH'}"
 #$FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "bugsnag_flutter_dart_io_http_client:{'path':'$DART_IO_WRAPPER_PACKAGE_PATH'}"
 

--- a/features/scripts/generate_fixture.sh
+++ b/features/scripts/generate_fixture.sh
@@ -29,7 +29,7 @@ BS_DART_LOCATION=features/fixture_resources/lib
 
 BS_DART_DESTINATION=features/fixtures/mazerunner
 
-# If flutter version = 3.38.3 or higher, change min sdk to 19
+# Change android gradle file based on flutter version
 if $FLUTTER_BIN --version | grep -qE 'Flutter 3\.(3[8-9]|[4-9][0-9]|[1-9][0-9]{2,})'; then
   ANDROID_GRADLE=features/fixtures/mazerunner/android/app/build.gradle.kts
 else
@@ -54,8 +54,8 @@ $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" path_provider
 
 $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" http
 
+# Change the version of native_flutter_proxy based on flutter version. >= 3.20.0 requires a newer version
 if $FLUTTER_BIN --version | grep -qE 'Flutter 3\.(2[0-9]|[3-9][0-9]|[1-9][0-9]{2,})'; then
-  echo "Using local native_flutter_proxy package for flutter version >= 3.20.0"
   $FLUTTER_BIN pub add --directory="$FIXTURE_LOCATION" "native_flutter_proxy"
   sed -i '' "s|import 'package:native_flutter_proxy/custom_proxy.dart';|import 'package:native_flutter_proxy/src/custom_proxy.dart';|" $BS_DART_LOCATION/main.dart
   sed -i '' "s|import 'package:native_flutter_proxy/native_proxy_reader.dart';|import 'package:native_flutter_proxy/src/native_proxy_reader.dart';|" $BS_DART_LOCATION/main.dart


### PR DESCRIPTION
## Goal

Add Flutter 3.19.0, 3.24.4 and 3.38.3 to the CI setup.
Move the fixture building steps into a single script to make it more readable on CI 
Update the `generate_fixture.sh` script to work with the new versions of Flutter (3.24.4 and 3.38.3)

Flutter 3.10.0 has been skipped due to minimum Dart version required by the `bugsnag_flutter_performance` plugin

## Testing

Covered by CI