### PR TITLE
upgrade device_info_plus and raise minimum Dart SDK to 3.5.0 and Flutter to 3.24.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         timeout_in_minutes: 10
         env:
           FLUTTER_VERSION: "{{matrix}}"
@@ -33,7 +32,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         timeout_in_minutes: 20
         env:
           FLUTTER_VERSION: "{{matrix}}"
@@ -50,7 +48,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         timeout_in_minutes: 20
         env:
           FLUTTER_VERSION: "{{matrix}}"
@@ -70,7 +67,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         env:
           FLUTTER_VERSION: "{{matrix}}"
         agents:
@@ -110,7 +106,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         env:
           FLUTTER_VERSION: "{{matrix}}"
         agents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## TBD
 
+* Upgrade device_info_plus and raise minimum Dart SDK to 3.5.0 and Flutter to 3.24.0 [#135](https://github.com/bugsnag/bugsnag-flutter-performance/pull/135)
+
 * Amend secondary instance URL to bugsnag.smartbear.com [#122](https://github.com/bugsnag/bugsnag-flutter-performance/pull/122)
 
 ## 1.7.0 (2025-09-22)

--- a/features/scripts/generate_fixture.sh
+++ b/features/scripts/generate_fixture.sh
@@ -95,6 +95,14 @@ echo "update min sdk version in android gradle file"
 
 sed -i '' 's/minSdkVersion flutter.minSdkVersion/minSdkVersion 19/g' "$ANDROID_GRADLE"
 
+echo "Fix Android Gradle Plugin version to meet Flutter 3.24+ requirements"
+
+# Update AGP version in settings.gradle (for newer Flutter templates)
+sed -i '' 's/id "com.android.application" version "[^"]*"/id "com.android.application" version "8.1.1"/g' features/fixtures/mazerunner/android/settings.gradle
+
+# Update AGP version in build.gradle (for older Flutter templates)
+sed -i '' "s/classpath 'com.android.tools.build:gradle:[^']*'/classpath 'com.android.tools.build:gradle:8.1.1'/g" features/fixtures/mazerunner/android/build.gradle
+
 echo "Add min platform to pod file"
 
 sed -i '' "s/# platform :ios, '11.0'/platform :ios, '12.0'/" "$PODFILE"

--- a/features/scripts/generate_fixture.sh
+++ b/features/scripts/generate_fixture.sh
@@ -95,13 +95,34 @@ echo "update min sdk version in android gradle file"
 
 sed -i '' 's/minSdkVersion flutter.minSdkVersion/minSdkVersion 19/g' "$ANDROID_GRADLE"
 
-echo "Fix Android Gradle Plugin version to meet Flutter 3.24+ requirements"
+echo "Fix Android Gradle Plugin and Kotlin versions"
 
-# Update AGP version in settings.gradle (for newer Flutter templates)
-sed -i '' 's/id "com.android.application" version "[^"]*"/id "com.android.application" version "8.1.1"/g' features/fixtures/mazerunner/android/settings.gradle
+# Determine required versions based on Flutter version
+if $FLUTTER_BIN --version | grep -qE 'Flutter 3\.(3[8-9]|[4-9][0-9]|[1-9][0-9]{2,})'; then
+  # Flutter 3.38+ - uses .gradle.kts files
+  AGP_VERSION="8.7.0"
+  KOTLIN_VERSION="2.1.0"
+  SETTINGS_FILE="features/fixtures/mazerunner/android/settings.gradle.kts"
+  BUILD_FILE="features/fixtures/mazerunner/android/build.gradle.kts"
+else
+  # Flutter < 3.38 - uses .gradle files
+  AGP_VERSION="8.6.0"
+  KOTLIN_VERSION="2.1.0"
+  SETTINGS_FILE="features/fixtures/mazerunner/android/settings.gradle"
+  BUILD_FILE="features/fixtures/mazerunner/android/build.gradle"
+fi
 
-# Update AGP version in build.gradle (for older Flutter templates)
-sed -i '' "s/classpath 'com.android.tools.build:gradle:[^']*'/classpath 'com.android.tools.build:gradle:8.1.1'/g" features/fixtures/mazerunner/android/build.gradle
+# Update AGP version in settings file if it exists
+if [ -f "$SETTINGS_FILE" ]; then
+  sed -i '' "s/id \"com.android.application\" version \"[^\"]*\"/id \"com.android.application\" version \"$AGP_VERSION\"/g" "$SETTINGS_FILE"
+  sed -i '' "s/id \"org.jetbrains.kotlin.android\" version \"[^\"]*\"/id \"org.jetbrains.kotlin.android\" version \"$KOTLIN_VERSION\"/g" "$SETTINGS_FILE"
+fi
+
+# Update AGP and Kotlin version in build file if it exists
+if [ -f "$BUILD_FILE" ]; then
+  sed -i '' "s/classpath 'com.android.tools.build:gradle:[^']*'/classpath 'com.android.tools.build:gradle:$AGP_VERSION'/g" "$BUILD_FILE"
+  sed -i '' "s/ext.kotlin_version = '[^']*'/ext.kotlin_version = '$KOTLIN_VERSION'/g" "$BUILD_FILE"
+fi
 
 echo "Add min platform to pod file"
 

--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -7,15 +7,15 @@ repository: https://github.com/bugsnag/bugsnag-flutter-performance
 issue_tracker: https://github.com/bugsnag/bugsnag-flutter-performance/issues
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: ">=3.19.0"
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: ">=3.24.0"
 
 dependencies:
   crypto: ^3.0.3
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  device_info_plus: '>=9.1.0 <12.0.0'
+  device_info_plus: '>=9.1.0 <13.0.0'
   package_info_plus: ^8.0.0
   path_provider: ^2.0.2
   uuid: ^4.0.0


### PR DESCRIPTION
This pull request updates the Flutter and Dart SDK version requirements and adjusts the CI pipeline to drop support for older Flutter versions. The main goal is to ensure compatibility with newer versions and streamline the supported environment.

**Dependency and SDK version updates:**

* Increased the minimum Dart SDK requirement to `>=3.5.0 <4.0.0` and the minimum Flutter version to `>=3.24.0` in `pubspec.yaml`.
* Updated the `device_info_plus` dependency to allow versions up to `<13.0.0` in `pubspec.yaml`.

**CI pipeline changes:**

* Removed Flutter version `3.19.0` from all build matrices in `.buildkite/pipeline.yml` to align with the new minimum supported Flutter version. [[1]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L15) [[2]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L36) [[3]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L53) [[4]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L73) [[5]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L113)