### PR TITLE
update the version constraint for the device_info_plus dependency and raise min flutter sdk version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         timeout_in_minutes: 10
         env:
           FLUTTER_VERSION: "{{matrix}}"
@@ -33,7 +32,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         timeout_in_minutes: 20
         env:
           FLUTTER_VERSION: "{{matrix}}"
@@ -50,7 +48,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         timeout_in_minutes: 20
         env:
           FLUTTER_VERSION: "{{matrix}}"
@@ -70,7 +67,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         env:
           FLUTTER_VERSION: "{{matrix}}"
         agents:
@@ -110,7 +106,6 @@ steps:
         matrix:
           - "3.38.3"
           - "3.24.4"
-          - "3.19.0"
         env:
           FLUTTER_VERSION: "{{matrix}}"
         agents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## TBD
 
+* Update the version constraint for the device_info_plus dependency [#136](https://github.com/bugsnag/bugsnag-flutter-performance/pull/136)
+
 * Amend secondary instance URL to bugsnag.smartbear.com [#122](https://github.com/bugsnag/bugsnag-flutter-performance/pull/122)
 
 ## 1.7.0 (2025-09-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## TBD
 
+* Raise the minimum supported flutter sdk version to 3.24.0 and the minimum dart version to 3.5.0 [#136](https://github.com/bugsnag/bugsnag-flutter-performance/pull/136)
+
 * Update the version constraint for the device_info_plus dependency [#136](https://github.com/bugsnag/bugsnag-flutter-performance/pull/136)
 
 * Amend secondary instance URL to bugsnag.smartbear.com [#122](https://github.com/bugsnag/bugsnag-flutter-performance/pull/122)

--- a/features/scripts/build_android_app.sh
+++ b/features/scripts/build_android_app.sh
@@ -2,12 +2,10 @@
 set -o errexit
 
 # Select Flutter binary
-# Prefer fvm if available, otherwise fall back to system flutter
-if command -v fvm >/dev/null 2>&1; then
-  FLUTTER_BIN="fvm flutter"
-else
-  FLUTTER_BIN="flutter"
-fi
+# Use FLUTTER_BIN if provided by CI, otherwise default to flutter
+FLUTTER_BIN="${FLUTTER_BIN:-flutter}"
+
+echo "Using Flutter binary: $FLUTTER_BIN"
 
 echo "--- 📦 Bundle Install"
 if ! bundle install; then
@@ -15,7 +13,6 @@ if ! bundle install; then
 fi
 
 echo "--- 🔧 Generate Fixture"
-echo "Running generate_fixture.sh script"
 ./features/scripts/generate_fixture.sh
 
 echo "--- 🚀 Building Flutter APK"

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -2,12 +2,8 @@
 set -o errexit
 
 # Select Flutter binary
-# Prefer fvm if available, otherwise fall back to system flutter
-if command -v fvm >/dev/null 2>&1; then
-  FLUTTER_BIN="fvm flutter"
-else
-  FLUTTER_BIN="flutter"
-fi
+# Use FLUTTER_BIN if provided by CI, otherwise default to flutter
+FLUTTER_BIN="${FLUTTER_BIN:-flutter}"
 
 echo "--- 📦 Bundle Install"
 if ! bundle install; then

--- a/features/scripts/generate_fixture.sh
+++ b/features/scripts/generate_fixture.sh
@@ -2,12 +2,8 @@
 set -o errexit
 
 # Select Flutter binary
-# Prefer fvm if available, otherwise fall back to system flutter
-if command -v fvm >/dev/null 2>&1; then
-  FLUTTER_BIN="fvm flutter"
-else
-  FLUTTER_BIN="flutter"
-fi
+# Use FLUTTER_BIN if provided by CI, otherwise default to flutter
+FLUTTER_BIN="${FLUTTER_BIN:-flutter}"
 
 FIXTURE_LOCATION=features/fixtures/mazerunner
 

--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -7,7 +7,7 @@ repository: https://github.com/bugsnag/bugsnag-flutter-performance
 issue_tracker: https://github.com/bugsnag/bugsnag-flutter-performance/issues
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.5.0 <4.0.0'
   flutter: ">=3.24.0"
 
 dependencies:

--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  device_info_plus: '>=9.1.0 <12.0.0'
+  device_info_plus: '>=9.1.0 <13.0.0'
   package_info_plus: ^8.0.0
   path_provider: ^2.0.2
   uuid: ^4.0.0

--- a/packages/bugsnag_flutter_performance/pubspec.yaml
+++ b/packages/bugsnag_flutter_performance/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/bugsnag/bugsnag-flutter-performance/issues
 
 environment:
   sdk: '>=3.3.0 <4.0.0'
-  flutter: ">=3.19.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   crypto: ^3.0.3


### PR DESCRIPTION
This pull request updates the Flutter version constraints and dependency requirements to support newer versions, and improves the build scripts for better compatibility with CI environments.

Dependency and environment updates:

* Increased the minimum supported Flutter version in `pubspec.yaml` from `3.19.0` to `3.24.0` and the min supported dart version from `3.3.0` to `3.5.0`, and expanded the `device_info_plus` dependency upper bound to allow versions up to `<13.0.0`.
* Removed Flutter `3.19.0` from all CI build matrices in `.buildkite/pipeline.yml`, so CI now only tests against supported Flutter versions. [[1]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L15) [[2]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L36) [[3]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L53) [[4]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L73) [[5]](diffhunk://#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L113)

Build script improvements:

* Updated all build and fixture scripts (`build_android_app.sh`, `build_ios_app.sh`, `generate_fixture.sh`) to use the `FLUTTER_BIN` environment variable if set, falling back to the default `flutter` binary. This improves compatibility with CI environments and tool version managers. [[1]](diffhunk://#diff-efabcc0d2a1ca1d98f57b5cdd9a79c3d3cfef898c42dbd6efcee6d0956bd92cfL5-L18) [[2]](diffhunk://#diff-a9ec8ddcc2bb8846fe53f7b9854d0c51b69df08c20dbbf4d0568e4e5272d84b7L5-R6) [[3]](diffhunk://#diff-6ad418efe1f2fc05605f880bb561feb9710f96f13980cd59662a31d9abfe1b4aL5-R6)

Documentation:

* Added a changelog entry describing the update to the `device_info_plus` dependency constraint.