### PR TITLE
align HTTP content-length attrs with OTel semantic conventions

### DIFF
--- a/features/fixture_resources/lib/scenarios/scenarios.dart
+++ b/features/fixture_resources/lib/scenarios/scenarios.dart
@@ -32,6 +32,7 @@ import 'pass_context_scenario.dart';
 import 'make_current_context.dart';
 import 'http_get_scenario.dart';
 import 'http_post_scenario.dart';
+import 'uncompressed_network_body_sizes_scenario.dart';
 import 'http_callback_edit_scenario.dart';
 import 'http_callback_cancel_span.dart';
 import 'dio_get_scenario.dart';
@@ -74,6 +75,8 @@ final List<ScenarioInfo<Scenario>> scenarios = [
       () => AutoInstrumentAppStartsScenario()),
   ScenarioInfo('HttpGetScenario', () => HttpGetScenario()),
   ScenarioInfo('HttpPostScenario', () => HttpPostScenario()),
+  ScenarioInfo('UncompressedNetworkBodySizesScenario',
+      () => UncompressedNetworkBodySizesScenario()),
   ScenarioInfo('HttpCallbackEditScenario', () => HttpCallbackEditScenario()),
   ScenarioInfo(
       'HttpCallbackCancelSpan', () => HttpCallbackCancelSpanScenario()),

--- a/features/fixture_resources/lib/scenarios/uncompressed_network_body_sizes_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/uncompressed_network_body_sizes_scenario.dart
@@ -2,11 +2,6 @@ import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
 
 import 'scenario.dart';
 
-/// Creates a span and sets the uncompressed request/response body size attributes.
-///
-/// This is used by MazeRunner feature tests to validate the
-/// [BugsnagPerformanceSpanAttributes.uncompressedRequestContentLength] and
-/// [BugsnagPerformanceSpanAttributes.uncompressedResponseContentLength] helpers.
 class UncompressedNetworkBodySizesScenario extends Scenario {
   @override
   Future<void> run() async {
@@ -17,9 +12,10 @@ class UncompressedNetworkBodySizesScenario extends Scenario {
 
     // Use a custom span so we can deterministically set attributes.
     final span = bugsnag_performance.startSpan('UncompressedBodySizes');
-    span.setAttribute('http.request.body.size', 123);
-    span.setAttribute('http.response.body.size', 456);
-    span.end();
+    span.end(
+      uncompressedRequestContentLength: 123,
+      uncompressedResponseContentLength: 456,
+    );
   }
 }
 

--- a/features/fixture_resources/lib/scenarios/uncompressed_network_body_sizes_scenario.dart
+++ b/features/fixture_resources/lib/scenarios/uncompressed_network_body_sizes_scenario.dart
@@ -1,0 +1,26 @@
+import 'package:bugsnag_flutter_performance/bugsnag_flutter_performance.dart';
+
+import 'scenario.dart';
+
+/// Creates a span and sets the uncompressed request/response body size attributes.
+///
+/// This is used by MazeRunner feature tests to validate the
+/// [BugsnagPerformanceSpanAttributes.uncompressedRequestContentLength] and
+/// [BugsnagPerformanceSpanAttributes.uncompressedResponseContentLength] helpers.
+class UncompressedNetworkBodySizesScenario extends Scenario {
+  @override
+  Future<void> run() async {
+    await startBugsnag();
+
+    // Ensure the batch is flushed immediately.
+    setMaxBatchSize(1);
+
+    // Use a custom span so we can deterministically set attributes.
+    final span = bugsnag_performance.startSpan('UncompressedBodySizes');
+    span.setAttribute('http.request.body.size', 123);
+    span.setAttribute('http.response.body.size', 456);
+    span.end();
+  }
+}
+
+

--- a/features/network_spans.feature
+++ b/features/network_spans.feature
@@ -14,7 +14,7 @@ Feature: Network Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: HTTP Post
     When I run "HttpPostScenario"
@@ -27,8 +27,8 @@ Feature: Network Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "POST"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.request_content_length" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.request.header.content-length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
     #this is to make sure that mutliple spans wont be created for the same request
   Scenario: HTTP Get Multiple Subscribers
@@ -50,7 +50,7 @@ Feature: Network Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "edited"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: HTTP Callback Cancel Span
     When I run "HttpCallbackCancelSpan"
@@ -75,6 +75,15 @@ Feature: Network Spans
     * I discard the oldest reflection
     * the reflection "traceparent" header matches the regex "^00-[A-Fa-f0-9]{32}-[A-Fa-f0-9]{16}-01"
 
+  Scenario: Uncompressed request/response body sizes
+    When I run "UncompressedNetworkBodySizesScenario"
+    And I wait to receive at least 1 span
+    Then the trace "Content-Type" header equals "application/json"
+    * the trace "Bugsnag-Span-Sampling" header equals "1:1"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0.name" equals "UncompressedBodySizes"
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.request.body.size" equals 123
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.body.size" equals 456
+
     #DIO WRAPPER
 
   Scenario: DIO Get
@@ -88,7 +97,7 @@ Feature: Network Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: DIO Post
     When I run "DIOPostScenario"
@@ -101,8 +110,8 @@ Feature: Network Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "POST"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.request_content_length" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.request.header.content-length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: DIO Callback Url Edit
     When I run "DIOCallbackEditScenario"
@@ -115,7 +124,7 @@ Feature: Network Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" equals "edited"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: DIO Callback Cancel Span
     When I run "DIOCallbackCancelSpan"
@@ -138,7 +147,7 @@ Feature: Network Spans
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.method" equals "GET"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" string attribute "http.url" matches the regex "^http:\/\/\S*:\d{4}(\/.*)?"
     * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.status_code" is greater than 0
-    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response_content_length" is greater than 0
+    * the trace payload field "resourceSpans.0.scopeSpans.0.spans.0" integer attribute "http.response.header.content-length" is greater than 0
 
   Scenario: Network callback type
     When I run "CheckNetworkCallbackTypeScenario"

--- a/packages/bugsnag_flutter_performance/lib/src/span.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span.dart
@@ -91,6 +91,8 @@ class BugsnagPerformanceSpanImpl
     int? httpStatusCode,
     int? requestContentLength,
     int? responseContentLength,
+    int? uncompressedRequestContentLength,
+    int? uncompressedResponseContentLength,
     bool cancelled = false,
     DateTime? endTime,
   }) {
@@ -110,6 +112,16 @@ class BugsnagPerformanceSpanImpl
     }
     if (responseContentLength != null && responseContentLength > 0) {
       attributes.responseContentLength = responseContentLength;
+    }
+    if (uncompressedRequestContentLength != null &&
+        uncompressedRequestContentLength > 0) {
+      attributes.uncompressedRequestContentLength =
+          uncompressedRequestContentLength;
+    }
+    if (uncompressedResponseContentLength != null &&
+        uncompressedResponseContentLength > 0) {
+      attributes.uncompressedResponseContentLength =
+          uncompressedResponseContentLength;
     }
     onEnded(this);
   }

--- a/packages/bugsnag_flutter_performance/lib/src/span.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span.dart
@@ -21,6 +21,8 @@ abstract class BugsnagPerformanceSpan implements BugsnagPerformanceSpanContext {
     int? httpStatusCode,
     int? requestContentLength,
     int? responseContentLength,
+    int? uncompressedRequestContentLength,
+    int? uncompressedResponseContentLength,
     bool cancelled = false,
     DateTime? endTime,
   });

--- a/packages/bugsnag_flutter_performance/lib/src/span.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span.dart
@@ -116,12 +116,12 @@ class BugsnagPerformanceSpanImpl
       attributes.responseContentLength = responseContentLength;
     }
     if (uncompressedRequestContentLength != null &&
-        uncompressedRequestContentLength > 0) {
+        uncompressedRequestContentLength >= 0) {
       attributes.uncompressedRequestContentLength =
           uncompressedRequestContentLength;
     }
     if (uncompressedResponseContentLength != null &&
-        uncompressedResponseContentLength > 0) {
+        uncompressedResponseContentLength >= 0) {
       attributes.uncompressedResponseContentLength =
           uncompressedResponseContentLength;
     }

--- a/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
@@ -49,58 +49,18 @@ class BugsnagPerformanceSpanAttributes {
     setAttribute('http.status_code', httpStatusCode);
   }
 
-  /// Set the HTTP request content length attribute on this span.
-  ///
-  /// This represents the number of bytes in the HTTP request body.
-  ///
-  /// Use [requestContentLength] to set the number of bytes in the request body.
-  ///
-  /// Attribute keys:
-  /// - Legacy: `"http.request_content_length"` (not currently used)
-  /// - Current: `"http.request.header.content-length"`
-  ///
-  /// [requestContentLength] the number of bytes in the request body.
   set requestContentLength(int requestContentLength) {
-    // setAttribute('http.request_content_length', requestContentLength);
     setAttribute('http.request.header.content-length', requestContentLength);
   }
 
-  /// Set the HTTP response content length attribute on this span.
-  ///
-  /// This represents the number of bytes in the HTTP response body.
-  ///
-  /// Use [responseContentLength] to set the number of bytes in the response body.
-  ///
-  /// Attribute keys:
-  /// - Legacy: `"http.response_content_length"` (not currently used)
-  /// - Current: `"http.response.header.content-length"`
-  ///
-  /// [responseContentLength] the number of bytes in the response body.
   set responseContentLength(int responseContentLength) {
-    // setAttribute('http.response_content_length', responseContentLength);
     setAttribute('http.response.header.content-length', responseContentLength);
   }
 
-  /// Set the HTTP uncompressed request content length attribute on this span.
-  ///
-  /// This represents the number of bytes in the *uncompressed* HTTP request body.
-  ///
-  /// Attribute key: `"http.request.body.size"`.
-  ///
-  /// [uncompressedRequestContentLength] the number of bytes in the uncompressed
-  /// request body.
   set uncompressedRequestContentLength(int uncompressedRequestContentLength) {
     setAttribute('http.request.body.size', uncompressedRequestContentLength);
   }
 
-  /// Set the HTTP uncompressed response content length attribute on this span.
-  ///
-  /// This represents the number of bytes in the *uncompressed* HTTP response body.
-  ///
-  /// Attribute key: `"http.response.body.size"`.
-  ///
-  /// [uncompressedResponseContentLength] the number of bytes in the uncompressed
-  /// response body.
   set uncompressedResponseContentLength(int uncompressedResponseContentLength) {
     setAttribute('http.response.body.size', uncompressedResponseContentLength);
   }

--- a/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
+++ b/packages/bugsnag_flutter_performance/lib/src/span_attributes.dart
@@ -49,12 +49,60 @@ class BugsnagPerformanceSpanAttributes {
     setAttribute('http.status_code', httpStatusCode);
   }
 
+  /// Set the HTTP request content length attribute on this span.
+  ///
+  /// This represents the number of bytes in the HTTP request body.
+  ///
+  /// Use [requestContentLength] to set the number of bytes in the request body.
+  ///
+  /// Attribute keys:
+  /// - Legacy: `"http.request_content_length"` (not currently used)
+  /// - Current: `"http.request.header.content-length"`
+  ///
+  /// [requestContentLength] the number of bytes in the request body.
   set requestContentLength(int requestContentLength) {
-    setAttribute('http.request_content_length', requestContentLength);
+    // setAttribute('http.request_content_length', requestContentLength);
+    setAttribute('http.request.header.content-length', requestContentLength);
   }
 
+  /// Set the HTTP response content length attribute on this span.
+  ///
+  /// This represents the number of bytes in the HTTP response body.
+  ///
+  /// Use [responseContentLength] to set the number of bytes in the response body.
+  ///
+  /// Attribute keys:
+  /// - Legacy: `"http.response_content_length"` (not currently used)
+  /// - Current: `"http.response.header.content-length"`
+  ///
+  /// [responseContentLength] the number of bytes in the response body.
   set responseContentLength(int responseContentLength) {
-    setAttribute('http.response_content_length', responseContentLength);
+    // setAttribute('http.response_content_length', responseContentLength);
+    setAttribute('http.response.header.content-length', responseContentLength);
+  }
+
+  /// Set the HTTP uncompressed request content length attribute on this span.
+  ///
+  /// This represents the number of bytes in the *uncompressed* HTTP request body.
+  ///
+  /// Attribute key: `"http.request.body.size"`.
+  ///
+  /// [uncompressedRequestContentLength] the number of bytes in the uncompressed
+  /// request body.
+  set uncompressedRequestContentLength(int uncompressedRequestContentLength) {
+    setAttribute('http.request.body.size', uncompressedRequestContentLength);
+  }
+
+  /// Set the HTTP uncompressed response content length attribute on this span.
+  ///
+  /// This represents the number of bytes in the *uncompressed* HTTP response body.
+  ///
+  /// Attribute key: `"http.response.body.size"`.
+  ///
+  /// [uncompressedResponseContentLength] the number of bytes in the uncompressed
+  /// response body.
+  set uncompressedResponseContentLength(int uncompressedResponseContentLength) {
+    setAttribute('http.response.body.size', uncompressedResponseContentLength);
   }
 
   set samplingProbability(double? samplingProbability) {

--- a/packages/bugsnag_flutter_performance/test/src/span_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/span_test.dart
@@ -103,6 +103,56 @@ void main() {
         expect(span.endTime!.nanosecondsSinceEpoch,
             equals(firstEndTime!.nanosecondsSinceEpoch));
       });
+
+      test(
+          'should store uncompressed request/response content lengths using the expected attribute keys',
+          () {
+        final span = BugsnagPerformanceSpanImpl(
+          name: 'Test name',
+          startTime: DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch,
+              isUtc: true),
+        );
+        span.clock = BugsnagClockImpl.instance;
+
+        span.end(
+          uncompressedRequestContentLength: 123,
+          uncompressedResponseContentLength: 456,
+        );
+
+        expect(
+          span.attributes.attributes['http.request.body.size'],
+          equals(123),
+        );
+        expect(
+          span.attributes.attributes['http.response.body.size'],
+          equals(456),
+        );
+      });
+
+      test(
+          'should not store uncompressed request/response content lengths when values are non-positive',
+          () {
+        final span = BugsnagPerformanceSpanImpl(
+          name: 'Test name',
+          startTime: DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch,
+              isUtc: true),
+        );
+        span.clock = BugsnagClockImpl.instance;
+
+        span.end(
+          uncompressedRequestContentLength: 0,
+          uncompressedResponseContentLength: -1,
+        );
+
+        expect(
+          span.attributes.attributes.containsKey('http.request.body.size'),
+          isFalse,
+        );
+        expect(
+          span.attributes.attributes.containsKey('http.response.body.size'),
+          isFalse,
+        );
+      });
     });
 
     group('fromJson', () {

--- a/packages/bugsnag_flutter_performance/test/src/span_test.dart
+++ b/packages/bugsnag_flutter_performance/test/src/span_test.dart
@@ -145,8 +145,8 @@ void main() {
         );
 
         expect(
-          span.attributes.attributes.containsKey('http.request.body.size'),
-          isFalse,
+          span.attributes.attributes['http.request.body.size'],
+          equals(0),
         );
         expect(
           span.attributes.attributes.containsKey('http.response.body.size'),


### PR DESCRIPTION
Renames:
- http.request_content_length -> http.request.header.content-length
- http.request_content_length_uncompressed -> http.request.body.size
- http.response_content_length -> http.response.header.content-length
- http.response_content_length_uncompressed -> http.response.body.size

## Goal

Align HTTP span attribute names with clearer semantic conventions and remove ambiguity between header Content-Length vs uncompressed body size.

## Design

Use explicit, structured keys:
http.*.header.content-length for values coming from the Content-Length header
http.*.body.size for uncompressed payload size

## Changeset

Renamed span attribute keys:
http.request_content_length → http.request.header.content-length
http.request_content_length_uncompressed → http.request.body.size
http.response_content_length → http.response.header.content-length
http.response_content_length_uncompressed → http.response.body.size
Updated tests asserting uncompressed sizes to expect http.request.body.size / http.response.body.size (see packages/bugsnag_flutter_performance/test/src/span_test.dart).

## Testing

Tested using automated test cases in Bitbar and Maze Runner.